### PR TITLE
Fix compilation error on PostgreSQL 14

### DIFF
--- a/pgbc/bcextension.c
+++ b/pgbc/bcextension.c
@@ -11,7 +11,7 @@
  * The extension control string is parsed with the same parser we use for
  * postgresql.conf.  An extension also has an installation script string,
  * containing SQL commands to create the extension's objects.
- * 
+ *
  * Copied from src/backend/commands/extension.c and modified to suit
  *
  * Portions Copyright (c) 1996-2022, PostgreSQL Global Development Group
@@ -1176,14 +1176,15 @@ execute_extension_script(Oid extensionOid, ExtensionControlFile *control,
 	save_nestlevel = NewGUCNestLevel();
 
 	if (client_min_messages < WARNING)
-		(void) set_config_option("client_min_messages", "warning",
+		(void) set_config_option_ext("client_min_messages", "warning",
 								 PGC_USERSET, PGC_S_SESSION,
+								 GetUserId(),
 								 GUC_ACTION_SAVE, true, 0, false);
 	if (log_min_messages < WARNING)
- 		(void) set_config_option_ext("log_min_messages", "warning",
- 									 PGC_SUSET, PGC_S_SESSION,
- 									 BOOTSTRAP_SUPERUSERID,
- 									 GUC_ACTION_SAVE, true, 0, false);
+		(void) set_config_option_ext("log_min_messages", "warning",
+								 PGC_SUSET, PGC_S_SESSION,
+								 BOOTSTRAP_SUPERUSERID,
+								 GUC_ACTION_SAVE, true, 0, false);
 
 	/*
 	 * Similarly disable check_function_bodies, to ensure that SQL functions

--- a/pgbc/compatibility.h
+++ b/pgbc/compatibility.h
@@ -99,6 +99,19 @@ _PU_HOOK;
 #define PG_ANALYZE_AND_REWRITE		pg_analyze_and_rewrite
 #endif
 
+/*
+ * PostgreSQL 15 introduces the ability to assign permissions to adjust server
+ * variables. This adds the call for the new function in previous PostgreSQL
+ * versions.
+ */
+#if PG_VERSION_NUM < 150000
+#define set_config_option_ext(name, value, context, source, srole, action, changeVal, \
+															elevel, is_reload) \
+	set_config_option(name, value, context, source, action, changeVal, elevel, \
+										is_reload)
+#endif
+
+
 #if PG_VERSION_NUM < 140000
 #define GETOBJECTDESCRIPTION(a)		getObjectDescription(a)
 #else


### PR DESCRIPTION
Signed-off-by: Jonathan S. Katz <jkatz@amazon.com>

*Issue #, if available:*

*Description of changes:*

PostgreSQL 15 added support for GUC privileges, which are not
available on PostgreSQL 14 and below. The corrected line was
using the PG15 interface for checking if a user has privileges
to access changing the logging level. Ensure that the extension
compiles both on PG15+ and < PG15.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
