### PR TITLE
Force use of "pg_config --pgxs" for builds 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
-ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-else
-subdir = contrib/pgbc
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif
 
 subdir = backcountry
 SUBDIRS = \

--- a/pgbc/Makefile
+++ b/pgbc/Makefile
@@ -5,13 +5,6 @@ PGFILEDESC	= "pgbc - PoC"
 DATA		= pgbc--1.0.sql
 EXTRA_CLEAN	= guc-file.c
 
-ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-else
-subdir = contrib/pgbc
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif

--- a/uni_api/Makefile
+++ b/uni_api/Makefile
@@ -1,11 +1,11 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,6 @@ REGRESS = uni_api
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/uni_api/uni_api.conf
 
-ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-else
-subdir = contrib/uni_api
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Newer extensions tend to use this by default as it makes it
simpler for users to build extensions when the PostgreSQL
toolchain is installed. Yes, "USE_PGXS=1" is only one
additional item to add, but if one is trying to build
without docs, it is one less thing to forget.

Signed-off-by: Jonathan S. Katz <jkatz@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
