### PR TITLE
Did the following function renames in bcextension.c so the names are …

### DIFF
--- a/pgbc/bcextension.c
+++ b/pgbc/bcextension.c
@@ -500,7 +500,7 @@ check_valid_version_name(const char *versionname)
  * Utility functions to handle extension-related path names
  */
 static bool
-is_extension_control_filename(const char *filename)
+pgbc_is_extension_control_filename(const char *filename)
 {
 	const char *extension = strrchr(filename, '.');
 
@@ -516,7 +516,7 @@ is_extension_script_filename(const char *filename)
 }
 
 static char *
-get_extension_control_directory(void)
+pgbc_get_extension_control_directory(void)
 {
 	char		sharepath[MAXPGPATH];
 	char	   *result;
@@ -562,7 +562,7 @@ get_extension_script_directory(ExtensionControlFile *control)
 	 * installation's share directory.
 	 */
 	if (!control->directory)
-		return get_extension_control_directory();
+		return pgbc_get_extension_control_directory();
 
 	if (is_absolute_path(control->directory))
 		return pstrdup(control->directory);
@@ -2178,7 +2178,7 @@ bc_available_extensions(PG_FUNCTION_ARGS)
 	SetSingleFuncCall(fcinfo, 0);
 
 	/* first grab conventional extensions */
-	location = get_extension_control_directory();
+	location = pgbc_get_extension_control_directory();
 	dir = AllocateDir(location);
 
 	/*
@@ -2198,7 +2198,7 @@ bc_available_extensions(PG_FUNCTION_ARGS)
 			Datum		values[3];
 			bool		nulls[3];
 
-			if (!is_extension_control_filename(de->d_name))
+			if (!pgbc_is_extension_control_filename(de->d_name))
 				continue;
 
 			/* extract extension name from 'name.control' filename */
@@ -2267,7 +2267,7 @@ bc_available_extensions(PG_FUNCTION_ARGS)
 			char	   *fname = SPI_getvalue(SPI_tuptable->vals[i],
 											 SPI_tuptable->tupdesc, 1);
 
-			if (!is_extension_control_filename(fname))
+			if (!pgbc_is_extension_control_filename(fname))
 				continue;
 
 			/* extract extension name from 'name.control' filename */
@@ -2336,7 +2336,7 @@ bc_available_extension_versions(PG_FUNCTION_ARGS)
 	SetSingleFuncCall(fcinfo, 0);
 
 	/* first grab conventional extensions */
-	location = get_extension_control_directory();
+	location = pgbc_get_extension_control_directory();
 	dir = AllocateDir(location);
 
 	/*
@@ -2354,7 +2354,7 @@ bc_available_extension_versions(PG_FUNCTION_ARGS)
 			ExtensionControlFile *control;
 			char	   *extname;
 
-			if (!is_extension_control_filename(de->d_name))
+			if (!pgbc_is_extension_control_filename(de->d_name))
 				continue;
 
 			/* extract extension name from 'name.control' filename */
@@ -2406,7 +2406,7 @@ bc_available_extension_versions(PG_FUNCTION_ARGS)
 			char	   *fname = SPI_getvalue(SPI_tuptable->vals[i],
 											 SPI_tuptable->tupdesc, 1);
 
-			if (!is_extension_control_filename(fname))
+			if (!pgbc_is_extension_control_filename(fname))
 				continue;
 
 			/* extract extension name from 'name.control' filename */


### PR DESCRIPTION
…not the same as in extension.c

  - get_extension_control_directory -> pgbc_is_extension_control_filename
  - is_extension_control_filename -> pgbc_is_extension_control_filename

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
