### PR TITLE
Adding an example password_check extension

### DIFF
--- a/examples/password_check/LICENSE
+++ b/examples/password_check/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/examples/password_check/README.md
+++ b/examples/password_check/README.md
@@ -1,0 +1,21 @@
+password_check
+==============
+
+A package that creates a function to check the complexity of a password. It can 
+be used with the *passcheck* feature of pg_tle. The function enforces the 
+following complexity rules:
+
+* The password must be at least 8 characters
+* Passwords between 8 and 16 characters must contain digits, lower and upper 
+  case characters
+* Passwords longer than 16 characters must contain lower and upper case 
+  characters
+* At least 3 unique passwords need to be used before the password can be repeated
+
+Installation
+------------
+Installing this extension is very simple:
+
+    psql -f password_check.sql postgres
+    psql -c "CREATE EXTENSION password_check" postgres
+    psql -c "SELECT backcountry.bc_feature_info_sql_insert('password_check.checkpass', 'passcheck')" postgres

--- a/examples/password_check/password_check.sql
+++ b/examples/password_check/password_check.sql
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+SELECT backcountry.install_extension
+(
+ 'password_check',
+ '1.0',
+$_password_check_$
+comment = 'A function that can be called from the backcountry feature passcheck'
+default_version = '1.0'
+module_pathname = 'pgbc_string'
+relocatable = false
+superuser = false
+trusted = true
+requires = 'plperl, pgcrypto, backcountry'
+$_password_check_$,
+  false,
+$_password_check_$
+CREATE SCHEMA password_check;
+REVOKE ALL on SCHEMA password_check FROM public;
+GRANT USAGE ON SCHEMA password_check TO PUBLIC;
+
+CREATE TABLE password_check.password_history (
+  username     text NOT NULL,
+  hash         text NOT NULL,
+  change_ts    timestamptz NOT NULL
+);
+REVOKE ALL on TABLE password_check.password_history FROM public;
+
+CREATE INDEX password_history_username 
+  ON password_check.password_history(username);
+
+CREATE FUNCTION password_check.checkpass(text, text, backcountry.password_types, timestamp, boolean) 
+  RETURNS void AS 
+$_$
+    my ($username, $pwd, $password_type, $validuntil_time, $validuntil_null) = @_;
+
+    unless($password_type == "PASSWORD_TYPE_PLAINTEXT") {
+        elog(WARNING, "Password not checked. Password Type is " . $password_type);
+        return;
+    }
+    my $len = length($pwd);
+
+    # passwords less than 8 characters are not allowed
+    if($len < 8){
+        elog(ERROR, 'Passwords needs to be longer than 8.');
+    }
+
+    # passwords less than 16 characters need numbers
+    if($len < 16) {
+      unless($pwd =~ /\d/ && $pwd =~ /[a-z]/ && $pwd =~ /[A-Z]/) {
+          elog(ERROR, 'Passwords less than 16 characters need to have digits, upper and lower case');
+      }
+    }
+
+    # passwords more than 16 characters only need upper and lower case
+    unless($pwd =~ /[a-z]/ && $pwd =~ /[A-Z]/){
+        elog(ERROR, 'Passwords need upper and lower case characters');
+    }
+
+    my $userpass = $pwd . $username;
+
+    my $plan1 = spi_prepare('SELECT 1
+                               FROM (SELECT hash 
+                                       FROM password_check.password_history 
+                                      WHERE username = $2 
+                                      ORDER BY change_ts DESC 
+                                      LIMIT 3) s
+                              WHERE s.hash = crypt($1, s.hash)', 
+                            'TEXT', 'TEXT');
+    my $rv = spi_query_prepared($plan1, $userpass, $username);
+    if (defined(my $row = spi_fetchrow($rv))) {
+      elog(ERROR, 'The password does not meet the password history requirement');
+    }
+    spi_cursor_close($rv);
+    spi_freeplan($plan1);
+
+    my $plan2 = spi_prepare('INSERT INTO password_check.password_history 
+                              VALUES ($1, crypt($2, gen_salt(\'bf\')), current_timestamp)', 
+                              'TEXT', 'TEXT');
+    spi_exec_prepared($plan2, $username, $userpass);
+    spi_freeplan($plan2);
+$_$
+SECURITY DEFINER
+LANGUAGE plperl;
+
+GRANT EXECUTE ON FUNCTION password_check.checkpass TO PUBLIC;
+$_password_check_$
+);


### PR DESCRIPTION
This adds a new example extension for a password check written in PL/Perl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
