### PR TITLE
Add cleanup to uni_api test

### DIFF
--- a/uni_api/expected/uni_api.out
+++ b/uni_api/expected/uni_api.out
@@ -97,3 +97,17 @@ INSERT INTO bc.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo(
 ALTER ROLE testuser with password '123456789';
 ERROR:  passcheck feature does not support calling out to functions/schemas that contain ';'
 HINT:  Check the bc.feature_info table does not contain ';' in it's entry.
+-- Clean up
+ALTER SYSTEM SET bc.enable_password_check = 'off';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+TRUNCATE bc.feature_info;
+DROP ROLE testuser;
+DROP EXTENSION uni_api CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function password_check_length_greater_than_8(text,text,bc.password_types,timestamp with time zone,boolean)
+drop cascades to function password_check_only_nums(text,text,bc.password_types,timestamp with time zone,boolean)

--- a/uni_api/sql/uni_api.sql
+++ b/uni_api/sql/uni_api.sql
@@ -65,3 +65,10 @@ ALTER ROLE testuser with password '123456789';
 TRUNCATE bc.feature_info;
 INSERT INTO bc.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';
+
+-- Clean up
+ALTER SYSTEM SET bc.enable_password_check = 'off';
+SELECT pg_reload_conf();
+TRUNCATE bc.feature_info;
+DROP ROLE testuser;
+DROP EXTENSION uni_api CASCADE;


### PR DESCRIPTION
Clean up roles and extensions at the end of uni_api.sql for consistent results across test runs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
