### PR TITLE
Fix regression in access to TLE schema

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -263,5 +263,5 @@ CREATE EVENT TRIGGER pg_tle_event_trigger_for_drop_function
    ON sql_drop
    EXECUTE FUNCTION EXTSCHEMA.pg_tle_feature_info_sql_drop();
 
-REVOKE ALL on SCHEMA EXTSCHEMA FROM public;
-GRANT USAGE on SCHEMA EXTSCHEMA TO public;
+REVOKE ALL ON SCHEMA EXTSCHEMA FROM PUBLIC;
+GRANT USAGE ON SCHEMA EXTSCHEMA TO pgtle_staff;


### PR DESCRIPTION
367003e3 introduced a regression where usage to the TLE schema was granted to PUBLIC instead of the "pgtle_staff" user. This commit reverts back to the original behavior.