### PR TITLE
pgtle functions return boolean instead of text

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -25,7 +25,7 @@ CREATE FUNCTION EXTSCHEMA.install_extension
   ctl_alt bool,
   sql_str text
 )
-RETURNS TEXT
+RETURNS boolean
 SET search_path TO 'EXTSCHEMA'
 AS 'MODULE_PATHNAME', 'pg_tle_install_extension'
 LANGUAGE C STRICT;
@@ -37,13 +37,13 @@ CREATE FUNCTION EXTSCHEMA.install_upgrade_path
   tovers text,
   sql_str text
 )
-RETURNS TEXT
+RETURNS boolean
 SET search_path TO 'EXTSCHEMA'
 AS 'MODULE_PATHNAME', 'pg_tle_install_upgrade_path'
 LANGUAGE C STRICT;
 
 CREATE FUNCTION EXTSCHEMA.uninstall_extension(extname text)
-RETURNS TEXT
+RETURNS boolean
 SET search_path TO 'EXTSCHEMA'
 AS $_pgtleie_$
   DECLARE
@@ -69,7 +69,7 @@ AS $_pgtleie_$
       EXECUTE dropsql;
     END LOOP;
 
-    RETURN 'OK';
+    RETURN true;
   END;
 $_pgtleie_$
 LANGUAGE plpgsql STRICT;

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -50,7 +50,7 @@ $_pgtle_$
 );
  install_extension 
 -------------------
- OK
+ t
 (1 row)
 
 SELECT pgtle.install_extension
@@ -76,7 +76,7 @@ $_pgtle_$
 );
  install_extension 
 -------------------
- OK
+ t
 (1 row)
 
 SET search_path TO public;
@@ -189,7 +189,7 @@ $_pgtle_$
 );
  install_extension 
 -------------------
- OK
+ t
 (1 row)
 
 SELECT pgtle.install_upgrade_path
@@ -207,7 +207,7 @@ $_pgtle_$
 );
  install_upgrade_path 
 ----------------------
- OK
+ t
 (1 row)
 
 SET search_path TO public;
@@ -317,13 +317,13 @@ SELECT CURRENT_USER;
 SELECT pgtle.uninstall_extension('test123');
  uninstall_extension 
 ---------------------
- OK
+ t
 (1 row)
 
 SELECT pgtle.uninstall_extension('testsuonlycreate');
  uninstall_extension 
 ---------------------
- OK
+ t
 (1 row)
 
 -- clean up


### PR DESCRIPTION
*Issue* 
fixes #27 

*Description of changes:*
pgtle functions return boolean instead of text

 * functions changed : pgtle.install_extension, pgtle.uninstall_extension, pgtle.install_upgrade_path
 * return true if succeeds, return false and provide error or warning if fails

*Tests*
Passes make installcheck

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

fixes #27