### PR TITLE
Simplify interface to pgtle.install_extension

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -19,16 +19,18 @@
 
 CREATE FUNCTION EXTSCHEMA.install_extension
 (
-  extname text,
-  extvers text,
-  ctl_str text,
-  ctl_alt bool,
-  sql_str text
+  name text,
+  version text,
+  trusted bool,
+  description text,
+  ext text,
+  requires text[] DEFAULT NULL,
+  encoding text DEFAULT NULL
 )
 RETURNS boolean
 SET search_path TO 'EXTSCHEMA'
 AS 'MODULE_PATHNAME', 'pg_tle_install_extension'
-LANGUAGE C STRICT;
+LANGUAGE C;
 
 CREATE FUNCTION EXTSCHEMA.install_upgrade_path
 (
@@ -113,11 +115,13 @@ LANGUAGE C STABLE STRICT;
 -- Revoke privs from PUBLIC
 REVOKE EXECUTE ON FUNCTION EXTSCHEMA.install_extension
 (
-  extname text,
-  extvers text,
-  ctr_str text,
-  ctr_alt bool,
-  sql_str text
+  name text,
+  version text,
+  trusted bool,
+  description text,
+  ext text,
+  requires text[],
+  encoding text
 ) FROM PUBLIC;
 
 REVOKE EXECUTE ON FUNCTION EXTSCHEMA.install_upgrade_path
@@ -151,11 +155,13 @@ GRANT USAGE, CREATE ON SCHEMA EXTSCHEMA TO pgtle_admin;
 
 GRANT EXECUTE ON FUNCTION EXTSCHEMA.install_extension
 (
-  extname text,
-  extvers text,
-  ctr_str text,
-  ctr_alt bool,
-  sql_str text
+  name text,
+  version text,
+  trusted bool,
+  description text,
+  ext text,
+  requires text[],
+  encoding text
 ) TO pgtle_admin;
 
 GRANT EXECUTE ON FUNCTION EXTSCHEMA.install_upgrade_path

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -31,15 +31,8 @@ SELECT pgtle.install_extension
 (
  'test123',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -57,15 +50,8 @@ SELECT pgtle.install_extension
 (
  'testsuonlycreate',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = true
-trusted = false
-$_pgtle_$,
-  false,
+ false,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION testsuonlycreate_func()
   RETURNS INT AS $$
@@ -105,11 +91,6 @@ SELECT test123_func();
            42
 (1 row)
 
--- unprivileged role can't create extensions that are not trusted and require superuser privilege
--- fails
-CREATE EXTENSION testsuonlycreate;
-ERROR:  permission denied to create extension "testsuonlycreate"
-HINT:  Must be superuser to create this extension.
 -- switch to dbstaff2
 SET SESSION AUTHORIZATION dbstaff2;
 SELECT CURRENT_USER;
@@ -165,15 +146,8 @@ SELECT pgtle.install_extension
 (
  'test123',
  '1.1',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.1'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -243,9 +217,9 @@ SELECT * FROM pgtle.available_extensions() ORDER BY name;
 SELECT * FROM pgtle.available_extension_versions() ORDER BY name;
        name       | version | superuser | trusted | relocatable | schema | requires |      comment       
 ------------------+---------+-----------+---------+-------------+--------+----------+--------------------
- test123          | 1.0     | f         | t       | f           |        |          | Test TLE Functions
- test123          | 1.1     | f         | t       | f           |        |          | Test TLE Functions
- testsuonlycreate | 1.0     | t         | f       | f           |        |          | Test TLE Functions
+ test123          | 1.0     | f         | t       | f           |        | {pg_tle} | Test TLE Functions
+ test123          | 1.1     | f         | t       | f           |        | {pg_tle} | Test TLE Functions
+ testsuonlycreate | 1.0     | f         | f       | f           |        | {pg_tle} | Test TLE Functions
 (3 rows)
 
 DROP EXTENSION test123;
@@ -275,15 +249,8 @@ SELECT pgtle.install_extension
 (
  'plpgsql',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -297,11 +264,13 @@ ERROR:  control file already exists for the plpgsql extension
 -- fail
 ALTER FUNCTION pgtle.install_extension
 (
-  extname text,
-  extvers text,
-  ctl_str text,
-  ctl_alt bool,
-  sql_str text
+  name text,
+  version text,
+  trusted bool,
+  description text,
+  ext text,
+  requires text[],
+  encoding text
 )
 SET search_path TO 'public';
 ERROR:  altering pg_tle functions in pgtle schema not allowed

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -34,15 +34,8 @@ SELECT pgtle.install_extension
 (
  'test123',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -56,15 +49,8 @@ SELECT pgtle.install_extension
 (
  'testsuonlycreate',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = true
-trusted = false
-$_pgtle_$,
-  false,
+ false,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION testsuonlycreate_func()
   RETURNS INT AS $$
@@ -87,10 +73,6 @@ SET SESSION AUTHORIZATION dbstaff;
 SELECT CURRENT_USER;
 CREATE EXTENSION test123;
 SELECT test123_func();
-
--- unprivileged role can't create extensions that are not trusted and require superuser privilege
--- fails
-CREATE EXTENSION testsuonlycreate;
 
 -- switch to dbstaff2
 SET SESSION AUTHORIZATION dbstaff2;
@@ -121,15 +103,8 @@ SELECT pgtle.install_extension
 (
  'test123',
  '1.1',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.1'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -199,15 +174,8 @@ SELECT pgtle.install_extension
 (
  'plpgsql',
  '1.0',
-$_pgtle_$
-comment = 'Test TLE Functions'
-default_version = '1.0'
-module_pathname = 'pg_tle_string'
-relocatable = false
-superuser = false
-trusted = true
-$_pgtle_$,
-  false,
+ true,
+ 'Test TLE Functions',
 $_pgtle_$
   CREATE OR REPLACE FUNCTION test123_func()
   RETURNS INT AS $$
@@ -221,11 +189,13 @@ $_pgtle_$
 -- fail
 ALTER FUNCTION pgtle.install_extension
 (
-  extname text,
-  extvers text,
-  ctl_str text,
-  ctl_alt bool,
-  sql_str text
+  name text,
+  version text,
+  trusted bool,
+  description text,
+  ext text,
+  requires text[],
+  encoding text
 )
 SET search_path TO 'public';
 


### PR DESCRIPTION
This removes passing in a "control file" string to pgtle.install_extension and changes the interface to use the following arguments:

* extname (text) - extension name
* extvers (text) - extension version
* exttrusted (bool) - true if trusted, false if not
* extdesc (text) - extension description
* sql_str (text) - contents of the extension

There are two optional arguments:

* extrequires (text[]) - array of requirements. "pg_tle" is automatically included

* extencode (text) - the encoding of the extensions contents.

This also adds a few opinions to the control file, including:

relocatable = false
superuser = false
default_version = $extvers

fixes #34
fixes #30