### PR TITLE
Fix issue preventing binary upgrades

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -3798,7 +3798,7 @@ _PU_HOOK
 						ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 							errmsg("control file not found for the %s extension", PG_TLE_EXTNAME)));
 				}
-				else
+				else if (!IsBinaryUpgrade)
 				{
 					/*
 					 * This is not a pg_tle extension artifact, so it does not


### PR DESCRIPTION
We need an explicit check when adding pg_tle scoped helper functions to the "pgtle" schema for "binary upgrade" mode. Otherwise, we block pg_upgrade, which is no good.

fixes #42