### PR TITLE
Rename pgtle.install_upgrade_path to pgtle.install_update_path

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -32,17 +32,17 @@ SET search_path TO 'EXTSCHEMA'
 AS 'MODULE_PATHNAME', 'pg_tle_install_extension'
 LANGUAGE C;
 
-CREATE FUNCTION EXTSCHEMA.install_upgrade_path
+CREATE FUNCTION EXTSCHEMA.install_update_path
 (
-  extname text,
-  fmvers text,
+  name text,
+  fromvers text,
   tovers text,
-  sql_str text
+  ext text
 )
 RETURNS boolean
 SET search_path TO 'EXTSCHEMA'
-AS 'MODULE_PATHNAME', 'pg_tle_install_upgrade_path'
-LANGUAGE C STRICT;
+AS 'MODULE_PATHNAME', 'pg_tle_install_update_path'
+LANGUAGE C;
 
 CREATE FUNCTION EXTSCHEMA.uninstall_extension(extname text)
 RETURNS boolean
@@ -124,12 +124,12 @@ REVOKE EXECUTE ON FUNCTION EXTSCHEMA.install_extension
   encoding text
 ) FROM PUBLIC;
 
-REVOKE EXECUTE ON FUNCTION EXTSCHEMA.install_upgrade_path
+REVOKE EXECUTE ON FUNCTION EXTSCHEMA.install_update_path
 (
-  extname text,
-  fmvers text,
+  name text,
+  fromvers text,
   tovers text,
-  sql_str text
+  ext text
 ) FROM PUBLIC;
 
 REVOKE EXECUTE ON FUNCTION EXTSCHEMA.uninstall_extension
@@ -164,12 +164,12 @@ GRANT EXECUTE ON FUNCTION EXTSCHEMA.install_extension
   encoding text
 ) TO pgtle_admin;
 
-GRANT EXECUTE ON FUNCTION EXTSCHEMA.install_upgrade_path
+GRANT EXECUTE ON FUNCTION EXTSCHEMA.install_update_path
 (
-  extname text,
-  fmvers text,
+  name text,
+  fromvers text,
   tovers text,
-  sql_str text
+  ext text
 ) TO pgtle_admin;
 
 GRANT EXECUTE ON FUNCTION EXTSCHEMA.uninstall_extension

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -166,7 +166,7 @@ $_pgtle_$
  t
 (1 row)
 
-SELECT pgtle.install_upgrade_path
+SELECT pgtle.install_update_path
 (
  'test123',
  '1.0',
@@ -179,8 +179,8 @@ $_pgtle_$
   )$$ LANGUAGE sql;
 $_pgtle_$
 );
- install_upgrade_path 
-----------------------
+ install_update_path 
+---------------------
  t
 (1 row)
 

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -119,7 +119,7 @@ $_pgtle_$
 $_pgtle_$
 );
 
-SELECT pgtle.install_upgrade_path
+SELECT pgtle.install_update_path
 (
  'test123',
  '1.0',


### PR DESCRIPTION
This also changes the function signature to be:

* name (text): name of the extension
* fromvers (text): from version
* tovers (text): to version
* ext (text): the contents of the extension

This commit adds some additional validation checking around name and fromvers/tovers to ensure we are not introducing invalid inputs.

fixes #35