### PR TITLE
Make all prefixes be "pgtle"

### DIFF
--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -89,7 +89,7 @@ passcheck_init(void)
 	next_check_password_hook = check_password_hook;
 	check_password_hook = passcheck_check_password_hook;
 
-	DefineCustomEnumVariable("pg_tle.enable_password_check",
+	DefineCustomEnumVariable("pgtle.enable_password_check",
 							 "Sets the behavior for interacting with passcheck feature.",
 							 NULL,
 							 &enable_passcheck_feature,

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -14,7 +14,7 @@
 -- Expect password to go through since we haven't enabled the feature
 CREATE ROLE testuser with password 'pass';
 -- Test 'on' / 'off' / 'require'
-ALTER SYSTEM SET pg_tle.enable_password_check = 'off';
+ALTER SYSTEM SET pgtle.enable_password_check = 'off';
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -22,7 +22,7 @@ SELECT pg_reload_conf();
 (1 row)
 
 ALTER ROLE testuser with password 'pass';
-ALTER SYSTEM SET pg_tle.enable_password_check = 'on';
+ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -34,7 +34,7 @@ ALTER ROLE testuser with password 'pass';
 CREATE EXTENSION pg_tle;
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
-ALTER SYSTEM SET pg_tle.enable_password_check = 'require';
+ALTER SYSTEM SET pgtle.enable_password_check = 'require';
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -98,7 +98,7 @@ ALTER ROLE testuser with password '123456789';
 ERROR:  passcheck feature does not support calling out to functions/schemas that contain ';'
 HINT:  Check the pgtle.feature_info table does not contain ';' in it's entry.
 DROP ROLE testuser;
-ALTER SYSTEM RESET pg_tle.enable_password_check;
+ALTER SYSTEM RESET pgtle.enable_password_check;
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -15,17 +15,17 @@
 -- Expect password to go through since we haven't enabled the feature
 CREATE ROLE testuser with password 'pass';
 -- Test 'on' / 'off' / 'require'
-ALTER SYSTEM SET pg_tle.enable_password_check = 'off';
+ALTER SYSTEM SET pgtle.enable_password_check = 'off';
 SELECT pg_reload_conf();
 ALTER ROLE testuser with password 'pass';
-ALTER SYSTEM SET pg_tle.enable_password_check = 'on';
+ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
 CREATE EXTENSION pg_tle;
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
-ALTER SYSTEM SET pg_tle.enable_password_check = 'require';
+ALTER SYSTEM SET pgtle.enable_password_check = 'require';
 SELECT pg_reload_conf();
 -- Expect an error for require if no entries are present
 ALTER ROLE testuser with password 'pass';
@@ -66,7 +66,7 @@ TRUNCATE pgtle.feature_info;
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';
 DROP ROLE testuser;
-ALTER SYSTEM RESET pg_tle.enable_password_check;
+ALTER SYSTEM RESET pgtle.enable_password_check;
 SELECT pg_reload_conf();
 DROP FUNCTION password_check_length_greater_than_8;
 DROP FUNCTION password_check_only_nums;


### PR DESCRIPTION
While it's OK to have the extension name as "pg_tle", we cannot prefix schema/roles with "pg_" as that is reserved by PostgreSQL. To make things consistent, anything that is user settable, e.g. config parameters (GUCs), will now be "pgtle" to limit confusion. We may also consider further refining everything to be "pgtle", but that can be decided in a future commit.

fixes #47