### PR TITLE
Add detection for trusted language in function definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJS = src/tleextension.o src/guc-file.o src/passcheck.o src/uni_api.o
 EXTRA_CLEAN	= src/guc-file.c pg_tle.control pg_tle--$(EXTVERSION).sql
 DATA_built = pg_tle.control pg_tle--$(EXTVERSION).sql
 
-REGRESS = pg_tle_api pg_tle_management pg_tle_injection
+REGRESS = pg_tle_api pg_tle_management pg_tle_injection pg_tle_language
 
 REGRESS_OPTS = --inputdir=test --temp-config ./regress.conf
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -28,6 +28,7 @@
 #define TLE_CTL_TRUSTED           "trusted"
 
 #define TLE_EXT_CONTROL_SUFFIX    ".control"
+#define TLE_EXT_LANG "language"
 #define TLE_EXT_SQL_SUFFIX        ".sql"
 
 /* general PostgreSQL names */

--- a/test/expected/pg_tle_language.out
+++ b/test/expected/pg_tle_language.out
@@ -1,0 +1,39 @@
+/*
+*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+\pset pager off
+CREATE EXTENSION pg_tle;
+-- attempt to create a TLE using a C-based function. This will error on
+-- CREATE EXTENSION
+SELECT pgtle.install_extension(
+  'tle_c',
+  '1.0',
+  FALSE,
+  'this will fail',
+$_pgtle_$
+  CREATE FUNCTION geo_distance (point, point)
+  RETURNS float8
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE AS '$libdir/earthdistance';
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+-- this will fail
+CREATE EXTENSION tle_c;
+ERROR:  language "c" is not trusted and cannot be used in a trusted-language function.
+-- cleanup
+SELECT pgtle.uninstall_extension('tle_c');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+DROP EXTENSION pg_tle;
+DROP SCHEMA pgtle;
+DROP ROLE pgtle_staff;
+DROP ROLE pgtle_admin;

--- a/test/sql/pg_tle_language.sql
+++ b/test/sql/pg_tle_language.sql
@@ -1,0 +1,33 @@
+/*
+*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+\pset pager off
+
+CREATE EXTENSION pg_tle;
+
+-- attempt to create a TLE using a C-based function. This will error on
+-- CREATE EXTENSION
+SELECT pgtle.install_extension(
+  'tle_c',
+  '1.0',
+  FALSE,
+  'this will fail',
+$_pgtle_$
+  CREATE FUNCTION geo_distance (point, point)
+  RETURNS float8
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE AS '$libdir/earthdistance';
+$_pgtle_$
+);
+
+-- this will fail
+CREATE EXTENSION tle_c;
+
+-- cleanup
+SELECT pgtle.uninstall_extension('tle_c');
+DROP EXTENSION pg_tle;
+DROP SCHEMA pgtle;
+DROP ROLE pgtle_staff;
+DROP ROLE pgtle_admin;


### PR DESCRIPTION
Prior to this, TLEs could add functions that used any language: trusted or untrusted, including referencing C functions that are already installed.

This patch restricts TLEs to only uses functions built from trusted languages.

A future patch can include a GUC with pg_tle to allow a user to explicitly opt into using an untrusted language.