### PR TITLE
Ensure pgtle.feature_info data is included in pg_dump

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -202,6 +202,8 @@ CREATE TABLE EXTSCHEMA.feature_info(
 	proname text,
 	obj_identity text);
 
+SELECT pg_catalog.pg_extension_config_dump('EXTSCHEMA.feature_info', '');
+
 CREATE INDEX feature_info_idx ON EXTSCHEMA.feature_info(feature);
 
 GRANT SELECT on EXTSCHEMA.feature_info TO PUBLIC;


### PR DESCRIPTION
Extensions that create tables do not carry data over in their dump files by default. This needs to be explicitly specified using as special function[1].

This patch calls this function on the pgtle.feature_info table to ensure any registered hooks are carried over in a pg_dump.

[1] https://www.postgresql.org/docs/14/extend-extensions.html#EXTEND-EXTENSIONS-CONFIG-TABLES