### PR TITLE
Ensure hook execution order is alphabetical

### DIFF
--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -153,7 +153,7 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 		 * Assume function accepts the proper argument, it'll error when we
 		 * call out to SPI_exec if it doesn't anyway
 		 */
-		query = psprintf("SELECT schema_name, proname FROM %s.%s WHERE feature = '%s'",
+		query = psprintf("SELECT schema_name, proname FROM %s.%s WHERE feature = '%s' ORDER BY proname",
 						 schema_name, feature_table_name, password_check_feature);
 
 		ret = SPI_execute(query, true, 0);


### PR DESCRIPTION
This follows the same pattern as PostgreSQL triggers and provides determinism.