### PR TITLE
Disallow duplicate hook registrations

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -200,11 +200,10 @@ CREATE TABLE EXTSCHEMA.feature_info(
 	feature EXTSCHEMA.pg_tle_features,
 	schema_name text,
 	proname text,
-	obj_identity text);
-
+	obj_identity text,
+  PRIMARY KEY(feature, schema_name, proname));
+  
 SELECT pg_catalog.pg_extension_config_dump('EXTSCHEMA.feature_info', '');
-
-CREATE INDEX feature_info_idx ON EXTSCHEMA.feature_info(feature);
 
 GRANT SELECT on EXTSCHEMA.feature_info TO PUBLIC;
 

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -92,6 +92,12 @@ INSERT INTO pgtle.feature_info VALUES ('passcheck', '', 'password_check_only_num
 -- Expect to fail cause no schema qualified function found
 ALTER ROLE testuser with password '123456789';
 ERROR:  Check entries in pgtle.feature_info table, schema and proname must be present
+-- test insert of duplicate hook and fail
+SELECT pgtle.pg_tle_feature_info_sql_insert('password_check_length_greater_than_8', 'passcheck');
+ERROR:  duplicate key value violates unique constraint "feature_info_pkey"
+DETAIL:  Key (feature, schema_name, proname)=(passcheck, public, password_check_length_greater_than_8) already exists.
+CONTEXT:  SQL statement "INSERT INTO pgtle.feature_info VALUES (feature, proc_schema_name, proname, ident)"
+PL/pgSQL function pgtle.pg_tle_feature_info_sql_insert(regproc,pgtle.pg_tle_features) line 24 at SQL statement
 TRUNCATE pgtle.feature_info;
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -62,6 +62,8 @@ ALTER ROLE testuser with password '123456789';
 INSERT INTO pgtle.feature_info VALUES ('passcheck', '', 'password_check_only_nums', '');
 -- Expect to fail cause no schema qualified function found
 ALTER ROLE testuser with password '123456789';
+-- test insert of duplicate hook and fail
+SELECT pgtle.pg_tle_feature_info_sql_insert('password_check_length_greater_than_8', 'passcheck');
 TRUNCATE pgtle.feature_info;
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';


### PR DESCRIPTION
This adds a PRIMARY KEY constraint on pgtle.feature_info to prevent duplicate hook registrations. Specifically, a hook of (hook,schema,funcname) combo can only be registered once.

fixes #23