### PR TITLE
Expose function to un-register feature

### DIFF
--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -202,7 +202,7 @@ CREATE TABLE EXTSCHEMA.feature_info(
 	proname text,
 	obj_identity text,
   PRIMARY KEY(feature, schema_name, proname));
-  
+
 SELECT pg_catalog.pg_extension_config_dump('EXTSCHEMA.feature_info', '');
 
 GRANT SELECT on EXTSCHEMA.feature_info TO PUBLIC;
@@ -238,6 +238,57 @@ BEGIN
 END;
 $$;
 
+-- Helper function to delete from table
+CREATE FUNCTION EXTSCHEMA.pg_tle_feature_info_sql_delete(proc regproc, feature EXTSCHEMA.pg_tle_features)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	pg_proc_relid oid;
+	proc_oid oid;
+	schema_name text;
+	nspoid oid;
+	proc_name text;
+	proc_schema_name text;
+	ident text;
+	row_count bigint;
+BEGIN
+	SELECT oid into nspoid
+  FROM pg_catalog.pg_namespace
+	WHERE nspname = 'pg_catalog';
+
+	SELECT oid into pg_proc_relid
+  FROM pg_catalog.pg_class
+	WHERE
+		relname = 'pg_proc' AND
+		relnamespace = nspoid;
+
+	SELECT
+		pg_namespace.nspname,
+		pg_proc.oid,
+		pg_proc.proname
+  INTO
+		proc_schema_name,
+		proc_oid,
+		proc_name
+	FROM pg_catalog.pg_namespace, pg_catalog.pg_proc
+	WHERE
+		pg_proc.oid = proc AND
+		pg_proc.pronamespace = pg_namespace.oid;
+
+	DELETE FROM EXTSCHEMA.feature_info
+	WHERE
+		feature_info.feature = $2 AND
+		feature_info.schema_name = proc_schema_name AND
+		feature_info.proname = proc_name;
+
+	GET DIAGNOSTICS row_count = ROW_COUNT;
+
+	IF ROW_COUNT = 0 THEN
+    RAISE EXCEPTION 'Could not unregister "%": does not exist.', $1;
+  END IF;
+END;
+$$;
 
 -- Prevent function from being dropped if referenced in table
 CREATE FUNCTION EXTSCHEMA.pg_tle_feature_info_sql_drop()

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -98,7 +98,24 @@ ERROR:  duplicate key value violates unique constraint "feature_info_pkey"
 DETAIL:  Key (feature, schema_name, proname)=(passcheck, public, password_check_length_greater_than_8) already exists.
 CONTEXT:  SQL statement "INSERT INTO pgtle.feature_info VALUES (feature, proc_schema_name, proname, ident)"
 PL/pgSQL function pgtle.pg_tle_feature_info_sql_insert(regproc,pgtle.pg_tle_features) line 24 at SQL statement
-TRUNCATE pgtle.feature_info;
+-- unregister hooks
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_only_nums', 'passcheck');
+ pg_tle_feature_info_sql_delete 
+--------------------------------
+ 
+(1 row)
+
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_length_greater_than_8', 'passcheck');
+ pg_tle_feature_info_sql_delete 
+--------------------------------
+ 
+(1 row)
+
+-- fail on unregistering a hook that does not exist
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_length_greater_than_8', 'passcheck');
+ERROR:  Could not unregister "password_check_length_greater_than_8": does not exist.
+CONTEXT:  PL/pgSQL function pgtle.pg_tle_feature_info_sql_delete(regproc,pgtle.pg_tle_features) line 44 at RAISE
+TRUNCATE TABLE pgtle.feature_info;
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';
 ERROR:  passcheck feature does not support calling out to functions/schemas that contain ';'

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -64,7 +64,12 @@ INSERT INTO pgtle.feature_info VALUES ('passcheck', '', 'password_check_only_num
 ALTER ROLE testuser with password '123456789';
 -- test insert of duplicate hook and fail
 SELECT pgtle.pg_tle_feature_info_sql_insert('password_check_length_greater_than_8', 'passcheck');
-TRUNCATE pgtle.feature_info;
+-- unregister hooks
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_only_nums', 'passcheck');
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_length_greater_than_8', 'passcheck');
+-- fail on unregistering a hook that does not exist
+SELECT pgtle.pg_tle_feature_info_sql_delete('password_check_length_greater_than_8', 'passcheck');
+TRUNCATE TABLE pgtle.feature_info;
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'test_foo;select foo()', '');
 ALTER ROLE testuser with password '123456789';
 DROP ROLE testuser;


### PR DESCRIPTION
This adds the
pg_tle_feature_info_sql_delete(proc regproc, feature EXTSCHEMA.pg_tle_features) function to "pg_tle" to allow for hooks to be unregistered programmatically.

fixes #58