### PR TITLE
Add ability to uninstall specific version of extension

### DIFF
--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -162,6 +162,27 @@ If the extension is currently activate within a database, `uninstall_extension` 
 SELECT pgtle.uninstall_extension('pg_tle_test');
 ```
 
+### `pgtle.uninstall_extension(extname text, version text)`
+
+`uninstall_extension` removes the specific version of an extension from the database. This prevents `CREATE EXTENSION` and `ALTER EXTENSION` from installing or updating to this version of the extension
+
+If this version of the extension is currently activate within a database, `uninstall_extension` **does not** drop it. You must explicitly call `DROP EXTENSION` to remove the extension.
+
+#### Role
+
+`pgtle_admin`
+
+#### Arguments
+
+* `extname`: The name of the extension. This is the value used when calling `CREATE EXTENSION`.
+* `version`: The version of the extension to uninstall.
+
+#### Example
+
+```sql
+SELECT pgtle.uninstall_extension('pg_tle_test', '0.2');
+```
+
 ### `pgtle.install_update_path(name text, fromvers text, tovers text, ext text)`
 
 `install_update_path` provides an update path between two different version of an extension. This enables user to call `ALTER EXTENSION ... UPDATE` for a Trusted-Language Extension.

--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -76,6 +76,33 @@ AS $_pgtleie_$
 $_pgtleie_$
 LANGUAGE plpgsql STRICT;
 
+
+-- uninstall an extension for a specific version
+CREATE FUNCTION EXTSCHEMA.uninstall_extension(extname text, version text)
+RETURNS boolean
+SET search_path TO 'EXTSCHEMA'
+AS $_pgtleie_$
+  DECLARE
+    sqlpattern text;
+    searchsql  text;
+    dropsql    text;
+    pgtlensp   text := 'EXTSCHEMA';
+    func       text;
+    row_count  bigint;
+  BEGIN
+    sqlpattern := format('%s--%%%s%%.sql', extname, version);
+    searchsql := 'SELECT proname FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE proname LIKE $1 AND n.nspname = $2';
+
+    FOR func IN EXECUTE searchsql USING sqlpattern, pgtlensp LOOP
+      dropsql := format('DROP FUNCTION %I()', func);
+      EXECUTE dropsql;
+    END LOOP;
+
+    RETURN TRUE;
+  END;
+$_pgtleie_$
+LANGUAGE plpgsql STRICT;
+
 CREATE FUNCTION EXTSCHEMA.extension_update_paths
 (
   name name,

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -303,6 +303,81 @@ ALTER FUNCTION pgtle.install_extension
 )
 SET search_path TO 'public';
 ERROR:  altering pg_tle functions in pgtle schema not allowed
+-- test uninstall extensions by a specific version
+SELECT pgtle.install_extension
+(
+ 'new_ext',
+ '1.0',
+ true,
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_extension
+(
+ 'new_ext',
+ '1.1',
+ true,
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 2; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.0',
+ '1.1',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 2; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
+SELECT *
+FROM pgtle.available_extension_versions() x WHERE x.name = 'new_ext';
+  name   | version | superuser | trusted | relocatable | schema | requires |      comment       
+---------+---------+-----------+---------+-------------+--------+----------+--------------------
+ new_ext | 1.0     | f         | t       | f           |        | {pg_tle} | Test TLE Functions
+ new_ext | 1.1     | f         | t       | f           |        | {pg_tle} | Test TLE Functions
+(2 rows)
+
+SELECT pgtle.uninstall_extension('new_ext', '1.1');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+SELECT *
+FROM pgtle.available_extension_versions() x WHERE x.name = 'new_ext';
+  name   | version | superuser | trusted | relocatable | schema | requires |      comment       
+---------+---------+-----------+---------+-------------+--------+----------+--------------------
+ new_ext | 1.0     | f         | t       | f           |        | {pg_tle} | Test TLE Functions
+(1 row)
+
+SELECT pgtle.uninstall_extension('new_ext');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
 -- back to our regular program: these should work
 -- removal of artifacts requires semi-privileged role
 SET SESSION AUTHORIZATION dbadmin;

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -226,6 +226,52 @@ ALTER FUNCTION pgtle.install_extension
 )
 SET search_path TO 'public';
 
+-- test uninstall extensions by a specific version
+SELECT pgtle.install_extension
+(
+ 'new_ext',
+ '1.0',
+ true,
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
+SELECT pgtle.install_extension
+(
+ 'new_ext',
+ '1.1',
+ true,
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 2; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.0',
+ '1.1',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 2; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
+SELECT *
+FROM pgtle.available_extension_versions() x WHERE x.name = 'new_ext';
+
+SELECT pgtle.uninstall_extension('new_ext', '1.1');
+
+SELECT *
+FROM pgtle.available_extension_versions() x WHERE x.name = 'new_ext';
+
+SELECT pgtle.uninstall_extension('new_ext');
+
 -- back to our regular program: these should work
 -- removal of artifacts requires semi-privileged role
 SET SESSION AUTHORIZATION dbadmin;


### PR DESCRIPTION
Adds to "uninstall_extension" with an optional parameter to specify a specific version of the extension to uninstall.

fixes #55