### PR TITLE
Updated privilege checks for creating TLE extensions

### DIFF
--- a/include/tleextension.h
+++ b/include/tleextension.h
@@ -21,6 +21,7 @@
 #define PG_TLE_MAGIC					"pg_tle_6ToRc5wJtKWTHWMn"
 #define PG_TLE_NSPNAME				"pgtle"
 #define PG_TLE_EXTNAME				"pg_tle"
+#define PG_TLE_ADMIN_ROLENAME			"pgtle_admin"
 #define PG_TLE_OUTER_STR			"$_pgtle_o_$"
 #define PG_TLE_INNER_STR			"$_pgtle_i_$"
 

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -18,6 +18,17 @@ GRANT pgtle_staff TO dbstaff2;
 CREATE ROLE dbguest;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO pgtle_admin;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO pgtle_staff;
+DO
+$$
+  DECLARE
+    dbname text;
+    sql text;
+  BEGIN
+    SELECT current_database() INTO dbname;
+    sql := format('GRANT CREATE ON DATABASE %I TO pgtle_staff', dbname);
+    EXECUTE sql;
+  END;
+$$ LANGUAGE plpgsql;
 -- create function that can be executed by superuser only
 CREATE OR REPLACE FUNCTION superuser_only()
 RETURNS INT AS $$
@@ -118,6 +129,11 @@ SELECT test123_func();
 -- fails
 CREATE EXTENSION test_no_switch_to_superuser_when_trusted;
 ERROR:  permission denied for function superuser_only
+-- unprivileged role can not create extensions that are not trusted
+-- fails
+CREATE EXTENSION test_superuser_only_when_untrusted;
+ERROR:  permission denied to create extension
+HINT:  Must be pgtle_admin to create this extension.
 -- switch to dbstaff2
 SET SESSION AUTHORIZATION dbstaff2;
 SELECT CURRENT_USER;
@@ -388,6 +404,17 @@ SELECT pgtle.uninstall_extension('test_no_switch_to_superuser_when_trusted');
 -- clean up
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION superuser_only();
+DO
+$$
+  DECLARE
+    dbname text;
+    sql text;
+  BEGIN
+    SELECT current_database() INTO dbname;
+    sql := format('REVOKE CREATE ON DATABASE %I FROM pgtle_staff', dbname);
+    EXECUTE sql;
+  END;
+$$ LANGUAGE plpgsql;
 DROP ROLE dbadmin;
 DROP ROLE dbstaff;
 DROP ROLE dbstaff2;


### PR DESCRIPTION
*Issue #, if available:*
63, 72, 73, 75

*Description of changes:*
* Creating extensions now requires CREATE privilege on the current database
* Creating untrusted extensions also requires pgtle_admin role
* Added a new regression test - untrusted extension creation requires pgtle_admin role
* Updated regression tests to grant CREATE on the current database

Fixes #63 
Fixes #72 
Fixes #73 
Fixes #75 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
