### PR TITLE
Fix Assert failure when installing a function twice

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4219,13 +4219,10 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-	  ErrorData  *errdata = CopyErrorData();
 
-	  if (errdata->sqlerrcode == ERRCODE_DUPLICATE_FUNCTION)
+	  if (geterrcode() == ERRCODE_DUPLICATE_FUNCTION)
 	  {
 	    FlushErrorState();
-	    FreeErrorData(errdata);
-
 	    ereport(ERROR,
 		    (errcode(ERRCODE_DUPLICATE_OBJECT),
 		     errmsg("Extension '%s' already installed.", extname)));


### PR DESCRIPTION
When we're in a PG_CATCH block, we cannot call out to CopyErrorData. Instead, just check the errcode
to clean up the error state and emit our own error.

On a fresh initdb, I ran make installcheck with cassert enabled and it passes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
