### PR TITLE
Fix possible name overrun when getting TLE extension name

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -542,8 +542,7 @@ get_extension_control_filename(const char *extname)
 	}
 	else
 	{
-		result = (char *) palloc(NAMEDATALEN);
-		snprintf(result, NAMEDATALEN, "%s.control", extname);
+		result = psprintf("%s.control", extname);
 	}
 
 	return result;


### PR DESCRIPTION
A carefully crafted string could take advantage of the previous MAXDATALEN limit to try to access data from a different TLE extension. This is likely a limited attack vector for numerous reasons, but it is better to be cleaner in our approach.

fixes #83