### PR TITLE
Ensure Github action pulls PostgreSQL packages from HTTPS endpoint

### DIFF
--- a/.github/workflows/test-pg-tle.yml
+++ b/.github/workflows/test-pg-tle.yml
@@ -13,7 +13,7 @@ jobs:
       run:  >
         sudo apt-get install -y curl ca-certificates gnupg &&
         curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null &&
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&
+        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&
         sudo apt-get update &&
         sudo apt-get install -y postgresql-14 postgresql-server-dev-14
     - name: Start postgresql


### PR DESCRIPTION
This was previously set to the apt.postgresql.org HTTP endpoint. While this is just isolated to GitHub action runs of our regression tests, it's still better to follow good download habits.