### PR TITLE
Gentler error handling when control file function has errors

### DIFF
--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -407,6 +407,39 @@ SELECT pgtle.uninstall_extension('new_ext');
  t
 (1 row)
 
+-- OK let's try to install an extension with a control file that has errors
+SELECT pgtle.install_extension
+(
+ 'broken_ext',
+ '0.1',
+ $$Distance functions for two points'
+ directory = '/tmp/$$,
+$_pg_tle_$
+    CREATE FUNCTION dist(x1 numeric, y1 numeric, x2 numeric, y2 numeric, l numeric)
+    RETURNS numeric
+    AS $$
+      SELECT ((x2 ^ l - x1 ^ l) ^ (1 / l)) + ((y2 ^ l - y1 ^ l) ^ (1 / l));
+    $$ LANGUAGE SQL;
+$_pg_tle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+-- this should lead to a sytnax error that we catch
+-- fail
+SELECT * FROM pgtle.available_extensions();
+ERROR:  syntax error in extension control function for 'broken_ext'.
+DETAIL:  Could not parse extension control function 'pgtle."broken_ext.control"'.
+HINT:  You may need to reinstall the extension to correct this error.
+-- shoo shoo and uninstall
+SELECT pgtle.uninstall_extension('broken_ext');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
 -- back to our regular program: these should work
 -- removal of artifacts requires semi-privileged role
 SET SESSION AUTHORIZATION dbadmin;

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -291,6 +291,29 @@ SELECT pgtle.set_default_version('bogus', '1.2');
 -- uninstall
 SELECT pgtle.uninstall_extension('new_ext');
 
+-- OK let's try to install an extension with a control file that has errors
+SELECT pgtle.install_extension
+(
+ 'broken_ext',
+ '0.1',
+ $$Distance functions for two points'
+ directory = '/tmp/$$,
+$_pg_tle_$
+    CREATE FUNCTION dist(x1 numeric, y1 numeric, x2 numeric, y2 numeric, l numeric)
+    RETURNS numeric
+    AS $$
+      SELECT ((x2 ^ l - x1 ^ l) ^ (1 / l)) + ((y2 ^ l - y1 ^ l) ^ (1 / l));
+    $$ LANGUAGE SQL;
+$_pg_tle_$
+);
+
+-- this should lead to a sytnax error that we catch
+-- fail
+SELECT * FROM pgtle.available_extensions();
+
+-- shoo shoo and uninstall
+SELECT pgtle.uninstall_extension('broken_ext');
+
 -- back to our regular program: these should work
 -- removal of artifacts requires semi-privileged role
 SET SESSION AUTHORIZATION dbadmin;


### PR DESCRIPTION
This is likely due to someone trying to put in a contrived comment or the like, but it can force undecipherable syntax errors. We may need to do some additional work to sanitize inputs coming from this function, but this at least gives the user guidance on how to get out of trouble.

Also ensures we force the "directory" value to NULL, though we do not reference it anywhere.

fixes #96