### PR TITLE
Add uninstall update path functions

### DIFF
--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -139,6 +139,35 @@ $_pgtle_$
 );
 ```
 
+### `pgtle.install_update_path(name text, fromvers text, tovers text, ext text)`
+
+`install_update_path` provides an update path between two different version of an extension. This enables user to call `ALTER EXTENSION ... UPDATE` for a Trusted-Language Extension.
+
+#### Role
+
+`pgtle_admin`
+
+#### Arguments
+
+* `name`: The name of the extension. This is the value used when calling `CREATE EXTENSION`.
+* `fromvers`: The source version of the extension for the upgrade.
+* `tovers`: The destination version of the extension for the upgrade.
+* `ext`: The contents of the update. This contains objects such as functions.
+
+#### Example
+
+```sql
+SELECT pgtle.install_update_path('pg_tle_test', '0.1', '0.2',
+  $_pgtle_$
+    CREATE OR REPLACE FUNCTION my_test()
+    RETURNS INT
+    AS $$
+      SELECT 21;
+    $$ LANGUAGE SQL IMMUTABLE;
+  $_pgtle_$
+);
+```
+
 ### `pgtle.register_feature(proc regproc, feature pg_tle_features)`
 
 `register_feature` provides a way to catalog functions that use `pg_tle` features such as [hooks](./04_hooks.md).
@@ -222,29 +251,9 @@ If the extension is currently active within a database, `uninstall_extension` **
 SELECT pgtle.uninstall_extension('pg_tle_test');
 ```
 
-### `pgtle.uninstall_extension_if_exists(extname text)`
-
-`uninstall_extension_if_exists` is similar to `uninstall_extension` in that it removes all versions of an extension from a database, but if the extension does not exist in the database, then no error is raised. `uninstall_extension_if_exists` returns true if the extension was uninstalled, and false if the extension did not exist.
-
-If the extension is currently active within a database, `uninstall_extension_if_exists` **does not** drop it. You must explicitly call `DROP EXTENSION` to remove the extension.
-
-#### Role
-
-`pgtle_admin`
-
-#### Arguments
-
-* `extname`: The name of the extension. This is the value used when calling `CREATE EXTENSION`.
-
-#### Example
-
-```sql
-SELECT pgtle.uninstall_extension_if_exists('pg_tle_test');
-```
-
 ### `pgtle.uninstall_extension(extname text, version text)`
 
-`uninstall_extension` removes the specific version of an extension from the database. This prevents `CREATE EXTENSION` and `ALTER EXTENSION` from installing or updating to this version of the extension
+`uninstall_extension` removes the specific version of an extension from the database. This prevents `CREATE EXTENSION` and `ALTER EXTENSION` from installing or updating to this version of the extension. This also removes all update paths that use this extension version.
 
 If this version of the extension is currently active within a database, `uninstall_extension` **does not** drop it. You must explicitly call `DROP EXTENSION` to remove the extension.
 
@@ -263,9 +272,11 @@ If this version of the extension is currently active within a database, `uninsta
 SELECT pgtle.uninstall_extension('pg_tle_test', '0.2');
 ```
 
-### `pgtle.install_update_path(name text, fromvers text, tovers text, ext text)`
+### `pgtle.uninstall_extension_if_exists(extname text)`
 
-`install_update_path` provides an update path between two different version of an extension. This enables user to call `ALTER EXTENSION ... UPDATE` for a Trusted-Language Extension.
+`uninstall_extension_if_exists` is similar to `uninstall_extension` in that it removes all versions of an extension from a database, but if the extension does not exist in the database, then no error is raised. `uninstall_extension_if_exists` returns true if the extension was uninstalled, and false if the extension did not exist.
+
+If the extension is currently active within a database, `uninstall_extension_if_exists` **does not** drop it. You must explicitly call `DROP EXTENSION` to remove the extension.
 
 #### Role
 
@@ -273,23 +284,12 @@ SELECT pgtle.uninstall_extension('pg_tle_test', '0.2');
 
 #### Arguments
 
-* `name`: The name of the extension. This is the value used when calling `CREATE EXTENSION`.
-* `fromvers`: The source version of the extension for the upgrade.
-* `tovers`: The destination version of the extension for the upgrade.
-* `ext`: The contents of the update. This contains objects such as functions.
+* `extname`: The name of the extension. This is the value used when calling `CREATE EXTENSION`.
 
 #### Example
 
 ```sql
-SELECT pgtle.install_update_path('pg_tle_test', '0.1', '0.2',
-  $_pgtle_$
-    CREATE OR REPLACE FUNCTION my_test()
-    RETURNS INT
-    AS $$
-      SELECT 21;
-    $$ LANGUAGE SQL IMMUTABLE;
-  $_pgtle_$
-);
+SELECT pgtle.uninstall_extension_if_exists('pg_tle_test');
 ```
 
 ### `pgtle.unregister_feature(proc regproc, feature pg_tle_features)`

--- a/pg_tle.sql.in
+++ b/pg_tle.sql.in
@@ -136,6 +136,52 @@ AS $_pgtleie_$
 $_pgtleie_$
 LANGUAGE plpgsql STRICT;
 
+-- uninstall a specific update path
+CREATE FUNCTION EXTSCHEMA.uninstall_update_path(extname text, fromvers text, tovers text)
+RETURNS boolean
+SET search_path TO 'EXTSCHEMA'
+AS $_pgtleie_$
+  DECLARE
+    sqlpattern text;
+    searchsql  text;
+    dropsql    text;
+    pgtlensp   text := 'EXTSCHEMA';
+    func       text;
+    existsvar  record;
+  BEGIN
+    sqlpattern := format('%s--%s--%s.sql', extname, fromvers, tovers);
+    searchsql := 'SELECT proname FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE proname = $1 AND n.nspname = $2';
+
+    EXECUTE searchsql USING sqlpattern, pgtlensp INTO existsvar;
+
+    IF existsvar IS NULL THEN
+      RAISE EXCEPTION 'Extension % does not exist', extname USING ERRCODE = 'no_data_found';
+    ELSE
+      FOR func IN EXECUTE searchsql USING sqlpattern, pgtlensp LOOP
+        dropsql := format('DROP FUNCTION %I()', func);
+        EXECUTE dropsql;
+      END LOOP;
+    END IF;
+
+    RETURN TRUE;
+  END;
+$_pgtleie_$
+LANGUAGE plpgsql STRICT;
+
+CREATE FUNCTION EXTSCHEMA.uninstall_update_path_if_exists(extname text, fromvers text, tovers text)
+RETURNS boolean
+SET search_path TO 'EXTSCHEMA'
+AS $_pgtleie_$
+BEGIN
+  PERFORM EXTSCHEMA.uninstall_update_path(extname, fromvers, tovers);
+  RETURN TRUE;
+EXCEPTION
+  WHEN no_data_found THEN
+    RETURN FALSE;
+END;
+$_pgtleie_$
+LANGUAGE plpgsql STRICT;
+
 CREATE FUNCTION EXTSCHEMA.extension_update_paths
 (
   name name,
@@ -213,6 +259,20 @@ REVOKE EXECUTE ON FUNCTION EXTSCHEMA.uninstall_extension_if_exists
   extname text
 ) FROM PUBLIC;
 
+REVOKE EXECUTE ON FUNCTION EXTSCHEMA.uninstall_update_path
+(
+  extname text,
+  fromvers text,
+  tovers text
+) FROM PUBLIC;
+
+REVOKE EXECUTE ON FUNCTION EXTSCHEMA.uninstall_update_path_if_exists
+(
+  extname text,
+  fromvers text,
+  tovers text
+) FROM PUBLIC;
+
 DO
 $_do_$
 BEGIN
@@ -267,6 +327,20 @@ GRANT EXECUTE ON FUNCTION EXTSCHEMA.uninstall_extension
 GRANT EXECUTE ON FUNCTION EXTSCHEMA.uninstall_extension_if_exists
 (
   extname text
+) TO pgtle_admin;
+
+GRANT EXECUTE ON FUNCTION EXTSCHEMA.uninstall_update_path
+(
+  extname text,
+  fromvers text,
+  tovers text
+) TO pgtle_admin;
+
+GRANT EXECUTE ON FUNCTION EXTSCHEMA.uninstall_update_path_if_exists
+(
+  extname text,
+  fromvers text,
+  tovers text
 ) TO pgtle_admin;
 
 CREATE TYPE EXTSCHEMA.pg_tle_features as ENUM ('passcheck');

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4399,7 +4399,8 @@ pg_tle_install_update_path(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_OBJECT),
 				 errmsg("Extension '%s' update path '%s-%s' already installed.",
-				 	extname, fromvers, tovers)));
+				 	extname, fromvers, tovers),
+				 errhint("To update this specific install path, first use \"%s.uninstall_update_path\".", PG_TLE_NSPNAME)));
 	  }
 
 		PG_RE_THROW();

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -427,6 +427,129 @@ $_pgtle_$
 $_pgtle_$
 );
 ERROR:  Extension 'new_ext' update path '1.0-1.1' already installed.
+HINT:  To update this specific install path, first use "pgtle.uninstall_update_path".
+-- add a downgrade path
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+ source | target |   path   
+--------+--------+----------
+ 1.0    | 1.1    | 1.0--1.1
+ 1.1    | 1.0    | 1.1--1.0
+(2 rows)
+
+-- only uninstall the downgrade path
+SELECT pgtle.uninstall_update_path('new_ext', '1.1', '1.0');
+ uninstall_update_path 
+-----------------------
+ t
+(1 row)
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+ source | target |   path   
+--------+--------+----------
+ 1.0    | 1.1    | 1.0--1.1
+ 1.1    | 1.0    | 
+(2 rows)
+
+-- try uninstalling again
+-- fail
+SELECT pgtle.uninstall_update_path('new_ext', '1.1', '1.0');
+ERROR:  Extension new_ext does not exist
+CONTEXT:  PL/pgSQL function uninstall_update_path(text,text,text) line 16 at RAISE
+-- try ininstall with if exists, see false
+SELECT pgtle.uninstall_update_path_if_exists('new_ext', '1.1', '1.0');
+ uninstall_update_path_if_exists 
+---------------------------------
+ f
+(1 row)
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+ source | target |   path   
+--------+--------+----------
+ 1.0    | 1.1    | 1.0--1.1
+ 1.1    | 1.0    | 
+(2 rows)
+
+-- install again and uninstall with "if exists", see true
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+ source | target |   path   
+--------+--------+----------
+ 1.0    | 1.1    | 1.0--1.1
+ 1.1    | 1.0    | 1.1--1.0
+(2 rows)
+
+SELECT pgtle.uninstall_update_path_if_exists('new_ext', '1.1', '1.0');
+ uninstall_update_path_if_exists 
+---------------------------------
+ t
+(1 row)
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+ source | target |   path   
+--------+--------+----------
+ 1.0    | 1.1    | 1.0--1.1
+ 1.1    | 1.0    | 
+(2 rows)
+
+-- ok, install it again
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
 -- test the default version, should be 1.0
 SELECT * FROM pgtle.available_extensions() x WHERE x.name = 'new_ext';
   name   | default_version |      comment       

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -312,6 +312,78 @@ $_pgtle_$
 $_pgtle_$
 );
 
+-- add a downgrade path
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+
+-- only uninstall the downgrade path
+SELECT pgtle.uninstall_update_path('new_ext', '1.1', '1.0');
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+
+-- try uninstalling again
+-- fail
+SELECT pgtle.uninstall_update_path('new_ext', '1.1', '1.0');
+
+-- try ininstall with if exists, see false
+SELECT pgtle.uninstall_update_path_if_exists('new_ext', '1.1', '1.0');
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+
+-- install again and uninstall with "if exists", see true
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+
+SELECT pgtle.uninstall_update_path_if_exists('new_ext', '1.1', '1.0');
+
+-- check avaiable update paths
+SELECT *
+FROM pgtle.extension_update_paths('new_ext') x
+ORDER BY x.source;
+
+-- ok, install it again
+SELECT pgtle.install_update_path
+(
+ 'new_ext',
+ '1.1',
+ '1.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION fun()
+  RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
+$_pgtle_$
+);
+
 -- test the default version, should be 1.0
 SELECT * FROM pgtle.available_extensions() x WHERE x.name = 'new_ext';
 


### PR DESCRIPTION
While "pgtle.uninstall_extension" will uninstall all of the update paths around a particular extension, a user may want to uninstall just one.

This commit adds `uninstall_update_path` and
`uninstall_update_path_if_exists` to give a finer tuned function for uninstall update paths for an extensions.

fixes #108