### PR TITLE
Fix segfault in password check hook

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -33,4 +33,15 @@
 /* general PostgreSQL names */
 #define PG_CTLG_SCHEMA            "pg_catalog"
 
+/* handling SPI_execute_with_args parameters. if we go beyond 9, add more */
+#define SPI_NARGS_1   1
+#define SPI_NARGS_2   2
+#define SPI_NARGS_3    3
+#define SPI_NARGS_4    4
+#define SPI_NARGS_5    5
+#define SPI_NARGS_6    6
+#define SPI_NARGS_7    7
+#define SPI_NARGS_8    8
+#define SPI_NARGS_9    9
+
 #endif							/* TLEEXTENSION_H */

--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -25,6 +25,8 @@
 #include "utils/guc.h"
 #include "utils/timestamp.h"
 #include "utils/fmgrprotos.h"
+
+#include "constants.h"
 #include "miscadmin.h"
 #include "tleextension.h"
 
@@ -139,8 +141,8 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 		uint64		j;
 		List	   *proc_names = NIL;
 		int			ret;
-		Oid		featargtypes[1] = { TEXTOID };
-		Datum		featargs[1];
+		Oid		featargtypes[SPI_NARGS_1] = { TEXTOID };
+		Datum		featargs[SPI_NARGS_1];
 
 		ret = SPI_connect();
 		if (ret != SPI_OK_CONNECT)
@@ -215,9 +217,11 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 		{
 			char			*query;
 			char			*func_name = lfirst(item);
-			Oid				hookargtypes[5] = { TEXTOID, TEXTOID, TEXTOID, TIMESTAMPTZOID, BOOLOID };
-			Datum			hookargs[5];
-			char			*hooknulls = "     ";
+			Oid				hookargtypes[SPI_NARGS_5] = { TEXTOID, TEXTOID, TEXTOID, TIMESTAMPTZOID, BOOLOID };
+			Datum			hookargs[SPI_NARGS_5];
+			char			hooknulls[SPI_NARGS_5];
+
+			memset(hooknulls, ' ', sizeof(hooknulls));
 
 			/* func_name is already using quote_identifier from when it was assembled */
 			query = psprintf("SELECT %s($1::pg_catalog.text, $2::pg_catalog.text, $3::%s.password_types, $4::pg_catalog.timestamptz, $5::pg_catalog.bool)",

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1525,8 +1525,8 @@ get_ext_ver_list(ExtensionControlFile *control)
 	{
 		int				spi_rc;
 		char			*sql;
-		Oid				sqlargtypes[2] = { TEXTOID, OIDOID };
-		Datum			sqlargs[2];
+		Oid				sqlargtypes[SPI_NARGS_2] = { TEXTOID, OIDOID };
+		Datum			sqlargs[SPI_NARGS_2];
 		int				i;
 		Oid				schemaOid = get_namespace_oid(PG_TLE_NSPNAME, false);
 		MemoryContext	ctx = CurrentMemoryContext;
@@ -2327,8 +2327,8 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 	{
 		int				spi_rc;
 		char			*sql;
-		Oid				sqlargtypes[1] = { OIDOID };
-		Datum			sqlargs[1];
+		Oid				sqlargtypes[SPI_NARGS_1] = { OIDOID };
+		Datum			sqlargs[SPI_NARGS_1];
 		int				i;
 		Oid				schemaOid = get_namespace_oid(PG_TLE_NSPNAME, false);
 		MemoryContext	ctx = CurrentMemoryContext;
@@ -2429,8 +2429,8 @@ pg_tle_available_extension_versions(PG_FUNCTION_ARGS)
 	{
 		int				spi_rc;
 		char			*sql;
-		Oid				sqlargtypes[1] = { OIDOID };
-		Datum			sqlargs[1];
+		Oid				sqlargtypes[SPI_NARGS_1] = { OIDOID };
+		Datum			sqlargs[SPI_NARGS_1];
 		int				i;
 		Oid				schemaOid = get_namespace_oid(PG_TLE_NSPNAME, false);
 		MemoryContext	ctx = CurrentMemoryContext;
@@ -4426,8 +4426,8 @@ pg_tle_set_default_version(PG_FUNCTION_ARGS)
 	char		*extvers;
 	char		*ctlname;
 	char		*versql;
-	Oid		verargtypes[2] = { TEXTOID, TEXTOID };
-	Datum		verargs[2];
+	Oid		verargtypes[SPI_NARGS_2] = { TEXTOID, TEXTOID };
+	Datum		verargs[SPI_NARGS_2];
 	StringInfo	ctlstr;
 	char		*ctlsql;
 	ExtensionControlFile	*control;


### PR DESCRIPTION
Not all compilers are smart enough to initialize a character pointer to an empty string. Which is another way of saying that this type was initialized improperly d37ddb1db and this now handles it correctly.