### PR TITLE
Updates to GitHub regression test action

### DIFF
--- a/.github/workflows/test-pg-tle.yml
+++ b/.github/workflows/test-pg-tle.yml
@@ -2,8 +2,11 @@ name: PostgreSQL 14 regression tests
 
 on:
   pull_request:
-    branches: [main]
-  workflow_dispatch:
+    branches:
+      - main
+  push:
+    branches:
+      - main 
 
 jobs:
   build:


### PR DESCRIPTION
This PR handles a few items:

* Moves to using the PostgreSQL 14 source, which was @adamguo0 original test
* Enables builds with casserts + debug symbols
* Enables TAP tests to run
* Now will run the regression tests on merges to `main`