### PR TITLE
Ensure reload changes are propagated in tests

### DIFF
--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -21,6 +21,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 ALTER ROLE testuser with password 'pass';
 ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
@@ -29,6 +31,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
 CREATE EXTENSION pg_tle;
@@ -41,8 +45,11 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 -- Expect an error for require if no entries are present
 ALTER ROLE testuser with password 'pass';
+ERROR:  pgtle.enable_password_check feature is set to require, however no entries exist in pgtle.feature_info with the feature passcheck
 -- Insert a value into the feature table
 CREATE OR REPLACE FUNCTION password_check_length_greater_than_8(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz,validuntil_null boolean) RETURNS void AS
 $$

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -17,9 +17,13 @@ CREATE ROLE testuser with password 'pass';
 -- Test 'on' / 'off' / 'require'
 ALTER SYSTEM SET pgtle.enable_password_check = 'off';
 SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 ALTER ROLE testuser with password 'pass';
 ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
 CREATE EXTENSION pg_tle;
@@ -27,6 +31,8 @@ CREATE EXTENSION pg_tle;
 ALTER ROLE testuser with password 'pass';
 ALTER SYSTEM SET pgtle.enable_password_check = 'require';
 SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 -- Expect an error for require if no entries are present
 ALTER ROLE testuser with password 'pass';
 -- Insert a value into the feature table


### PR DESCRIPTION
There is a known race condition in "pg_reload_conf()" where the postmaster reload does not complete in time before the next command is execute. Thus the current connection may be pulling server info that is stale.

There are several solutions for this, but within the context of the tests we can reconnect with "\c -", which is way better than sleeping.

fixes #115