### PR TITLE
Change short option for sqldir, add MAC OS support

### DIFF
--- a/tools/pg_tle_manage_local_extension/README.md
+++ b/tools/pg_tle_manage_local_extension/README.md
@@ -86,7 +86,7 @@ OPTIONS:
     -m, --runmake
           Run make to generate SQL file 
 
-    -d, --sqldir <subdir where SQL is present>
+    -s, --sqldir <subdir where SQL is present>
           set subdir where extension SQL files are
 
 EXIT_CODES:

--- a/tools/pg_tle_manage_local_extension/pg_tle_manage_local_extension.sh
+++ b/tools/pg_tle_manage_local_extension/pg_tle_manage_local_extension.sh
@@ -290,7 +290,7 @@ case "$Action" in
       SQL_FILE=$(mktemp .$$.XXXXXXXXXXXXXXXXXXX.sql)
       (echo "\\set ON_ERROR_STOP true";echo ${SQL_QUERY}) >${SQL_FILE}
       RUN_PGSQL ${SQL_FILE}
-      rm -f ${SQL_FILE}
+      [ ${DEBUG} -eq 0 ] && rm -f ${SQL_FILE}
       if [ ${PG_EXIT} -gt 0 ]; then
         echo "Failed to run SQL from ${SQL_FILE}"
         break


### PR DESCRIPTION
Description of changes:

1. Change short option for --sqldir from -s to -d
2. Fix where multiple SQL new install sql files are present
3. -d --debug will print some debug info
4. Now this script can be executed on MACOS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
