### PR TITLE
Fixes pg_restore for TLE-installed extensions

### DIFF
--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -232,15 +232,14 @@ SELECT * FROM pgtle.available_extension_versions() ORDER BY name;
 (3 rows)
 
 DROP EXTENSION test123;
--- negative tests, run as superuser
-RESET SESSION AUTHORIZATION;
+-- negative tests, run as unprivileged role
 -- should fail
 -- attempt to create a function in pgtle directly
 CREATE OR REPLACE FUNCTION pgtle.foo()
 RETURNS TEXT AS $$
 SELECT 'ok'
 $$ LANGUAGE sql;
-ERROR:  pgtle schema reserved for pg_tle functions
+ERROR:  permission denied for schema pgtle
 -- create a function in public and then attempt alter to pg_tle
 -- this works
 CREATE OR REPLACE FUNCTION public.pg_tlefoo()
@@ -252,6 +251,8 @@ ALTER FUNCTION public.pg_tlefoo() SET SCHEMA pgtle;
 ERROR:  pgtle schema reserved for pg_tle functions
 -- clean up, should work
 DROP FUNCTION public.pg_tlefoo();
+-- negative tests, run as superuser
+RESET SESSION AUTHORIZATION;
 -- attempt to shadow existing file-based extension
 -- fail
 SELECT pgtle.install_extension

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -162,9 +162,7 @@ SELECT * FROM pgtle.available_extensions() ORDER BY name;
 SELECT * FROM pgtle.available_extension_versions() ORDER BY name;
 DROP EXTENSION test123;
 
--- negative tests, run as superuser
-RESET SESSION AUTHORIZATION;
-
+-- negative tests, run as unprivileged role
 -- should fail
 -- attempt to create a function in pgtle directly
 CREATE OR REPLACE FUNCTION pgtle.foo()
@@ -184,6 +182,9 @@ ALTER FUNCTION public.pg_tlefoo() SET SCHEMA pgtle;
 
 -- clean up, should work
 DROP FUNCTION public.pg_tlefoo();
+
+-- negative tests, run as superuser
+RESET SESSION AUTHORIZATION;
 
 -- attempt to shadow existing file-based extension
 -- fail


### PR DESCRIPTION
Issue #, if available:
#154 

Description of changes:

* Record a dependency of .sql and .control functions on pg_tle extension when installing a TLE.
* Block CREATE OR REPLACE only on pre-existing tle-installed .sql and .control functions, but allow for new tle-installed .sql and .control functions.
 - If an unauthorized user tries to replace functions after they've been installed, or install new functions with the same 
    names, they will still fail as before
 - Function creation for new installs are still prevented by unauthorized users because of the default permissions on the 
    pgtle schema as granted by
```
REVOKE ALL ON SCHEMA pgtle FROM PUBLIC;
GRANT USAGE ON SCHEMA pgtle TO PUBLIC;
```

Tested manually with
```
CREATE EXTENSION pg_tle;
SELECT pgtle.install_extension
(
 'test123',
 '1.1',
 'Test TLE Functions',
$_pgtle_$
  CREATE OR REPLACE FUNCTION test123_func()
  RETURNS INT AS $$
  (
    SELECT 42
  )$$ LANGUAGE sql;
$_pgtle_$
);
CREATE EXTENSION test123;
```

Dumped to sql and confirmed order
pg_dump pgtledb > pgtledb.sql

Restored on a newly created database
psql -d pgtledbnew -f pgtledb.sql

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
