### PR TITLE
Build fixes for PG13 + CI support

### DIFF
--- a/.github/workflows/test-pg13.yaml
+++ b/.github/workflows/test-pg13.yaml
@@ -1,0 +1,65 @@
+name: PostgreSQL 13 regression tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Append /usr/local/pgsql/bin to PATH
+      run:  echo "/usr/local/pgsql/bin" >> $GITHUB_PATH
+    - name: Uninstall Ubuntu's postgresql installation
+      run:  sudo apt purge -y postgresql-14 postgresql-client-14 postgresql-client-common postgresql-common libpq-dev
+    - name: Do an apt-get update
+      run:  sudo apt-get update
+    - name: Install build dependencies for postgresql
+      run:  sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache libperl-dev
+    - name: Install CPAN dependencies
+      run:  sudo cpan -i "IPC::Run"
+    - name: download postgresql
+      run:  >
+        cd ~ &&
+        curl -O https://ftp.postgresql.org/pub/source/v13.9/postgresql-13.9.tar.gz &&
+        curl -O https://ftp.postgresql.org/pub/source/v13.9/postgresql-13.9.tar.gz.sha256
+    - name: verify postgresql
+      run:  >
+        cd ~ &&
+        sha256sum --check postgresql-13.9.tar.gz.sha256
+    - name: build postgresql
+      run:  >
+        cd ~ &&
+        tar xzf postgresql-13.9.tar.gz &&
+        cd postgresql-13.9 &&
+        ./configure --enable-tap-tests --enable-cassert --enable-debug --with-openssl --with-perl &&
+        make &&
+        sudo PATH=$PATH make install &&
+        cd contrib && make && sudo PATH=$PATH make install &&
+        cd ../src/test/perl && sudo PATH=$PATH make install
+    - name: initialize postgresql database
+      run:  >
+        mkdir ~/data &&
+        chmod -R 700 ~/data &&
+        initdb -D ~/data &&
+        pg_ctl -D ~/data start
+    - uses: actions/checkout@v3
+    - name: Compile pg_tle extension
+      run:  make
+    - name: Install pg_tle extension
+      run:  sudo PATH=$PATH make install
+    - name: Add pg_tle to shared_preload_libraries
+      run:  >
+        echo "shared_preload_libraries = 'pg_tle'" >> ~/data/postgresql.conf
+    - name: Restart postgresql
+      run:  pg_ctl -D ~/data restart
+    - name: Run pg_tle regression tests
+      id:   regression-tests
+      run:  PERL5LIB="${HOME}/postgresql-13.9/src/test/perl:${PERL5LIB}" make installcheck
+    - name: Print regression.diffs if regression tests failed
+      if:   failure() && steps.regression-tests.outcome != 'success'
+      run:  cat regression.diffs

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -118,8 +118,9 @@ _PU_HOOK;
 #define GETOBJECTDESCRIPTION(a)		getObjectDescription(a, false)
 #endif
 
-/* if prior to pg13, upgrade to newer macro defs */
-#ifndef PG_FINALLY
+/* if prior to pg13, upgrade to newer macro defs.
+ * This also adds support for PG_FINALLY  */
+#if PG_VERSION_NUM < 130000
 #ifdef PG_TRY
 #undef PG_TRY
 #endif
@@ -153,7 +154,7 @@ _PU_HOOK;
 		error_context_stack = _save_context_stack; \
 	} while (0)
 
-#endif	/* PG_FINALLY not defined */
+#endif	/* macro defs (e.g. PG_FINALLY) */
 
 /* also prior to pg13, add some newer macro defs */
 #ifndef TYPALIGN_CHAR

--- a/src/guc-file.l
+++ b/src/guc-file.l
@@ -20,7 +20,7 @@
 #include "miscadmin.h"
 #include "storage/fd.h"
 #include "utils/guc.h"
-
+#include "utils/memutils.h"
 
 /*
  * flex emits a yy_fatal_error() function that it calls in response to


### PR DESCRIPTION
This fixes a noticed break when building against PostgreSQL 13, and adds a automated workflow to test `pg_tle` for PostgreSQL 13.