### PR TITLE
Fix build issues on PG12 + add CI support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [REL_15_STABLE, REL_14_STABLE, REL_13_STABLE]
+        version: [REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -81,4 +81,6 @@ jobs:
           popd
       - name: Print regression.diffs if regression tests failed
         if:   failure() && steps.regression-tests.outcome != 'success'
-        run:  cat regression.diffs
+        run: |
+          pushd postgres
+          cat contrib/pg_tle/regression.diffs

--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "postgres.h"
+#include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
 #include "commands/extension.h"
 #include "commands/user.h"
@@ -29,6 +30,7 @@
 #include "constants.h"
 #include "miscadmin.h"
 #include "tleextension.h"
+#include "compatibility.h"
 
 void		passcheck_init(void);
 
@@ -185,7 +187,7 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 		tuptable = SPI_tuptable;
 		tupdesc = tuptable->tupdesc;
 
-		for (j = 0; j < tuptable->numvals; j++)
+		for (j = 0; j < SPI_NUMVALS(tuptable); j++)
 		{
 			HeapTuple	tuple = tuptable->vals[j];
 			int			i;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -89,6 +89,12 @@
 #include "tleextension.h"
 #include "compatibility.h"
 
+/* 
+ * Use our version-specific static declaration here for the
+ * process utility hook.
+ */
+_PU_HOOK;
+
 extern bool tleParseConfigFp(FILE *fp, const char *config_file,
 							int depth, int elevel, ConfigVariable **head_p,
 							ConfigVariable **tail_p);
@@ -2169,13 +2175,14 @@ static Oid get_tlefunc_oid_if_exists(const char *funcname)
 {
 	char	   *qualname = NULL;
 	List	   *namelist = NULL;
-		
+	Oid	     argtypes[1];
+
 	qualname = psprintf("%s.%s",
 			    quote_identifier(PG_TLE_NSPNAME),
 			    quote_identifier(funcname));
 	namelist = stringToQualifiedNameList(qualname);
 
-	return LookupFuncName(namelist, 0, NULL, true /* missing_ok */);
+	return LookupFuncName(namelist, 0, argtypes, true /* missing_ok */);
 }
 
 /*


### PR DESCRIPTION
This adds in a compatibility macro for "PG_CATCH" on versions of PostgreSQL older than 13 (where PG_FINALLY was introduced). We likely did not have any code that used PG_CATCH when the shim was introduced.

This also adds CI for building and testing PG12.