### PR TITLE
Add compatibility + CI/CD for PG11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
+        version: [master, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
For PostgreSQL 11, we needed to add support for the updated ereport syntax and additional functions from a2a8acd1 and a8671545. This also adds CI/CD for PostgreSQL 11.

fixes #169