### PR TITLE
Docs: supporting MacOS

### DIFF
--- a/tools/pg_tle_manage_local_extension/README.md
+++ b/tools/pg_tle_manage_local_extension/README.md
@@ -75,7 +75,8 @@ OPTIONS:
 
     -p, --extpath <Extension Path>
           A required parameter for install action.
-          Local path of the extension
+          Local path of the extension.
+          Must be a fully
 
     -h, --help
           Print help information
@@ -106,7 +107,8 @@ pg_tle_manage_local_extension.sh 1.0
 
 ## Install extension
 
-`./pg_tle_manage_local_extension.sh --action install --connection "postgresql://myuser@localhost:5432/mydb?sslmode=prefer" --name mv_stats --extpath ~/mv_stats`
+- Linux: `./pg_tle_manage_local_extension.sh --action install --connection "postgresql://myuser@localhost:5432/mydb?sslmode=prefer" --name mv_stats --extpath ~/mv_stats`
+- MacOS: `./pg_tle_manage_local_extension.sh -a install -c "postgresql://myuser@localhost:5432/mydb?sslmode=prefer" -n mv_stats -p ~/mv_stats`
 
 ```
 Installing mv_stats  from ~/mv_stats in postgresql://myuser@localhost:5432/mydb?sslmode=prefer

--- a/tools/pg_tle_manage_local_extension/README.md
+++ b/tools/pg_tle_manage_local_extension/README.md
@@ -76,7 +76,6 @@ OPTIONS:
     -p, --extpath <Extension Path>
           A required parameter for install action.
           Local path of the extension.
-          Must be a fully
 
     -h, --help
           Print help information

--- a/tools/pg_tle_manage_local_extension/README.md
+++ b/tools/pg_tle_manage_local_extension/README.md
@@ -75,7 +75,7 @@ OPTIONS:
 
     -p, --extpath <Extension Path>
           A required parameter for install action.
-          Local path of the extension.
+          Local path of the extension
 
     -h, --help
           Print help information


### PR DESCRIPTION
I tried following the docs and immediately ran into an error `Long arguments are not supported on MACOS`

This change is a suggestion to add better MacOS support. If you agree with the approach, I can do the same for the other commands.

