### PR TITLE
Provide a minimum version of PostgreSQL for pg_tle

### DIFF
--- a/docs/01_install.md
+++ b/docs/01_install.md
@@ -9,6 +9,7 @@ There are a few ways you can install Trusted Language Extensions for PostgreSQL 
 #### Prerequisites
 
 - [`git`](https://git-scm.com/)
+- PostgreSQL 11 or later
 - [`pg_config`](https://www.postgresql.org/docs/current/app-pgconfig.html)
 - PostgreSQL development files
 


### PR DESCRIPTION
This specifies the current minimum version of PostgreSQL for `pg_tle`,
which happens to be PostgreSQL 11.

fixes #175