### PR TITLE
Fix "requires" for file-based extensions

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1538,7 +1538,11 @@ get_ext_ver_list(ExtensionControlFile *control)
 		dir = AllocateDir(location);
 
 		while ((de = ReadDir(dir, location)) != NULL)
-			fnames = lappend(fnames, makeString(de->d_name));
+		{
+			char *s;
+			s = pstrdup(de->d_name);
+			fnames = lappend(fnames, makeString(s));
+		}
 
 		FreeDir(dir);
 	}


### PR DESCRIPTION
An issue with how file-based extension version files were copied while building the dependency graph caused bogus names to be available, and would prevent the proper requires tree from working if there were both TLE / file-based extensions in the dependency tree. This ensures the copy is handled in a way that does not send garbage.

fixes #183