### PR TITLE
Support full install and uninstall of multiple versions of an extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MODULE_big = $(EXTENSION)
 OBJS = src/tleextension.o src/guc-file.o src/feature.o src/passcheck.o src/uni_api.o
 
 EXTRA_CLEAN	= src/guc-file.c pg_tle.control pg_tle--$(EXTVERSION).sql
-DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql
+DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql
 
 REGRESS = pg_tle_api pg_tle_management pg_tle_injection pg_tle_perms pg_tle_requires
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = pg_tle
-EXTVERSION = 1.0.1
+EXTVERSION = 1.0.4
 
 SCHEMA = pgtle
 MODULE_big = $(EXTENSION)

--- a/pg_tle--1.0.1--1.0.4.sql
+++ b/pg_tle--1.0.1--1.0.4.sql
@@ -37,7 +37,6 @@ AS $_pgtleie_$
   DECLARE
     ctrpattern         text;
     sqlpattern         text;
-    sqlverpattern      text;
     countverssql       text;
     vers_count         bigint;
     defaultversql      text;
@@ -51,7 +50,6 @@ AS $_pgtleie_$
   BEGIN
     ctrpattern := format('%s%%.control', extname);
     sqlpattern := format('%s--%%%s%%.sql', extname, version);
-    sqlverpattern := format('%s--%s.sql', extname, version);
     countverssql := format('SELECT COUNT(*) FROM %s.%s WHERE name = $1', pgtlensp, func_available_vers);
     defaultversql := format('SELECT default_version FROM %s.%s WHERE name = $1', pgtlensp, func_available_ext);
     searchsql := 'SELECT proname FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE proname LIKE $1 AND n.nspname = $2';
@@ -65,7 +63,7 @@ AS $_pgtleie_$
         RAISE EXCEPTION 'Can not uninstall default version of extension %, use set_default_version to update the default to another available version and retry', extname;
       ELSE
         -- remove the specified version sql file function only, don't remove control file function
-        FOR func IN EXECUTE searchsql USING sqlverpattern, pgtlensp LOOP
+        FOR func IN EXECUTE searchsql USING sqlpattern, pgtlensp LOOP
           dropsql := format('DROP FUNCTION %I()', func);
           EXECUTE dropsql;
         END LOOP;

--- a/pg_tle--1.0.1--1.0.4.sql
+++ b/pg_tle--1.0.1--1.0.4.sql
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_tle" to load this file. \quit
+
+
+-- uninstall an extension for a specific version
+CREATE FUNCTION pgtle.install_extension_version_sql
+(
+  name text,
+  version text,
+  ext text
+)
+RETURNS boolean
+SET search_path TO 'pgtle'
+AS 'MODULE_PATHNAME', 'pg_tle_install_extension_version_sql'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION pgtle.uninstall_extension(extname text, version text)
+RETURNS boolean
+SET search_path TO 'pgtle'
+AS $_pgtleie_$
+  DECLARE
+    ctrpattern         text;
+    sqlpattern         text;
+    sqlverpattern      text;
+    countverssql       text;
+    vers_count         bigint;
+    defaultversql      text;
+    defaultver         text;
+    searchsql          text;
+    dropsql            text;
+    pgtlensp           text := 'pgtle';
+    func_available_vers text := 'available_extension_versions()';
+    func_available_ext text := 'available_extensions()';
+    func               text;
+  BEGIN
+    ctrpattern := format('%s%%.control', extname);
+    sqlpattern := format('%s--%%%s%%.sql', extname, version);
+    sqlverpattern := format('%s--%s.sql', extname, version);
+    countverssql := format('SELECT COUNT(*) FROM %s.%s WHERE name = $1', pgtlensp, func_available_vers);
+    defaultversql := format('SELECT default_version FROM %s.%s WHERE name = $1', pgtlensp, func_available_ext);
+    searchsql := 'SELECT proname FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE proname LIKE $1 AND n.nspname = $2';
+
+    EXECUTE countverssql USING extname INTO vers_count;
+    EXECUTE defaultversql USING extname INTO defaultver;
+
+    IF vers_count > 1 THEN
+      -- if multiple versions exist and this is the default version, don't uninstall
+      IF version = defaultver THEN
+        RAISE EXCEPTION 'Can not uninstall default version of extension %, use set_default_version to update the default to another available version and retry', extname;
+      ELSE
+        -- remove the specified version sql file function only, don't remove control file function
+        FOR func IN EXECUTE searchsql USING sqlverpattern, pgtlensp LOOP
+          dropsql := format('DROP FUNCTION %I()', func);
+          EXECUTE dropsql;
+        END LOOP;
+      END IF;
+    ELSE
+      -- check that the specified version matches the only version that exists
+      -- if it does then uninstall the extension completely
+      -- if it doesn't then don't uninstall anything to avoid accidental uninstall
+      IF version = defaultver THEN
+        FOR func IN EXECUTE searchsql USING ctrpattern, pgtlensp LOOP
+          dropsql := format('DROP FUNCTION %I()', func);
+          EXECUTE dropsql;
+        END LOOP;
+        FOR func IN EXECUTE searchsql USING sqlpattern, pgtlensp LOOP
+          dropsql := format('DROP FUNCTION %I()', func);
+          EXECUTE dropsql;
+        END LOOP;
+      ELSE
+        RAISE EXCEPTION 'Version % of extension % is not installed and therefore can not be uninstalled', extname, version;
+      END IF;
+    END IF;
+    
+    RETURN TRUE;
+  END;
+$_pgtleie_$
+LANGUAGE plpgsql STRICT;
+
+-- Revoke privs from PUBLIC
+REVOKE EXECUTE ON FUNCTION pgtle.install_extension_version_sql
+(
+  name text,
+  version text,
+  ext text
+) FROM PUBLIC;
+
+-- Grant privs to only pgtle_admin
+GRANT EXECUTE ON FUNCTION pgtle.install_extension_version_sql
+(
+  name text,
+  version text,
+  ext text
+) TO pgtle_admin;

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -661,7 +661,6 @@ SELECT pgtle.uninstall_extension('test_no_switch_to_superuser_when_trusted');
 (1 row)
 
 RESET SESSION AUTHORIZATION;
-ALTER EXTENSION pg_tle UPDATE TO '1.0.4';
 SELECT pgtle.install_extension
 (
  'test42',

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -660,6 +660,181 @@ SELECT pgtle.uninstall_extension('test_no_switch_to_superuser_when_trusted');
  t
 (1 row)
 
+RESET SESSION AUTHORIZATION;
+ALTER EXTENSION pg_tle UPDATE TO '1.0.4';
+SELECT pgtle.install_extension
+(
+ 'test42',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(1 row)
+
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension_version_sql 
+-------------------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+ (test42,2.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(2 rows)
+
+-- install an already installed version
+-- fails
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ERROR:  version "2.0" of extension "test42" already installed
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+ (test42,2.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(2 rows)
+
+-- uninstall default version
+-- fails
+SELECT pgtle.uninstall_extension('test42', '1.0');
+ERROR:  Can not uninstall default version of extension test42, use set_default_version to update the default to another available version and retry
+CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 30 at RAISE
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+ (test42,2.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(2 rows)
+
+-- uninstall a version that is not the default version
+-- succeeds
+SELECT pgtle.uninstall_extension('test42', '2.0');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(1 row)
+
+-- uninstall non-existent version
+-- fails
+SELECT pgtle.uninstall_extension('test42', '3.0');
+ERROR:  Version test42 of extension 3.0 is not installed and therefore can not be uninstalled
+CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 52 at RAISE
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(1 row)
+
+-- uninstall the only installed and  default version
+SELECT pgtle.uninstall_extension('test42', '1.0');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+ available_extension_versions 
+------------------------------
+(0 rows)
+
+SELECT pgtle.install_extension
+(
+ 'test42',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension_version_sql 
+-------------------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+           available_extension_versions            
+---------------------------------------------------
+ (test42,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
+ (test42,2.0,f,f,f,,{pg_tle},"Test TLE Functions")
+(2 rows)
+
+-- uninstall extension with multiple versions
+SELECT pgtle.uninstall_extension('test42');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extension_versions();
+ available_extension_versions 
+------------------------------
+(0 rows)
+
 -- clean up
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION superuser_only();

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -736,7 +736,7 @@ SELECT pgtle.available_extension_versions();
 -- fails
 SELECT pgtle.uninstall_extension('test42', '1.0');
 ERROR:  Can not uninstall default version of extension test42, use set_default_version to update the default to another available version and retry
-CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 30 at RAISE
+CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 28 at RAISE
 SELECT pgtle.available_extension_versions();
            available_extension_versions            
 ---------------------------------------------------
@@ -762,7 +762,7 @@ SELECT pgtle.available_extension_versions();
 -- fails
 SELECT pgtle.uninstall_extension('test42', '3.0');
 ERROR:  Version test42 of extension 3.0 is not installed and therefore can not be uninstalled
-CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 52 at RAISE
+CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 50 at RAISE
 SELECT pgtle.available_extension_versions();
            available_extension_versions            
 ---------------------------------------------------

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -449,8 +449,6 @@ SELECT pgtle.uninstall_extension('test_no_switch_to_superuser_when_trusted');
 
 RESET SESSION AUTHORIZATION;
 
-ALTER EXTENSION pg_tle UPDATE TO '1.0.4';
-
 SELECT pgtle.install_extension
 (
  'test42',

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -447,6 +447,111 @@ SELECT CURRENT_USER;
 SELECT pgtle.uninstall_extension('test123');
 SELECT pgtle.uninstall_extension('test_no_switch_to_superuser_when_trusted');
 
+RESET SESSION AUTHORIZATION;
+
+ALTER EXTENSION pg_tle UPDATE TO '1.0.4';
+
+SELECT pgtle.install_extension
+(
+ 'test42',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.available_extension_versions();
+
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.available_extension_versions();
+
+-- install an already installed version
+-- fails
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.available_extension_versions();
+
+-- uninstall default version
+-- fails
+SELECT pgtle.uninstall_extension('test42', '1.0');
+SELECT pgtle.available_extension_versions();
+
+-- uninstall a version that is not the default version
+-- succeeds
+SELECT pgtle.uninstall_extension('test42', '2.0');
+SELECT pgtle.available_extension_versions();
+
+-- uninstall non-existent version
+-- fails
+SELECT pgtle.uninstall_extension('test42', '3.0');
+SELECT pgtle.available_extension_versions();
+
+-- uninstall the only installed and  default version
+SELECT pgtle.uninstall_extension('test42', '1.0');
+SELECT pgtle.available_extension_versions();
+
+SELECT pgtle.install_extension
+(
+ 'test42',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.install_extension_version_sql
+(
+ 'test42',
+ '2.0',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test42_func()
+  RETURNS INT AS $$
+  (
+    SELECT 4242
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.available_extension_versions();
+
+-- uninstall extension with multiple versions
+SELECT pgtle.uninstall_extension('test42');
+
+SELECT pgtle.available_extension_versions();
+
 -- clean up
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION superuser_only();


### PR DESCRIPTION
Issue #186

Description of changes:

Support for full install sql files of multiple versions of an extension, and corresponding uninstall functionality

1. Added the following function
**pgtle.install_extension_version_sql(name text, version text, ext text)**
which installs only the sql file of an extension version when another version of the extension is already installed, i.e., a control file and sql file for another version is already installed. No changes are made to the already installed control file.

2. Updated the following function
**pgtle.uninstall_extension(extname text, version text)**
which will now behave as follows

If extension + version does not exist -> error

If extension + version exists and is not the default_version -> uninstall extension/version combination

If extension + version exists and is the default_version and other versions exist -> error and hint to use
set_default_version to update the default to another available version before retrying

If extension + version exists and is the default_version and no other versions exist -> uninstall the extension and control file


3. Added regression tests for the new functions

4. Added pg_tle version update script

5. Updated documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
