### PR TITLE
Make a comment more technically correct

### DIFF
--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -97,9 +97,9 @@
 #endif
 
 /*
- * PostgreSQL 15 introduces the ability to assign permissions to adjust server
- * variables. This adds the call for the new function in previous PostgreSQL
- * versions.
+ * PostgreSQL 15 Beta3 (commit a2944d8724) introduces the ability to assign
+ * permissions to adjust server variables. This adds the call for the new
+ * function in PostgreSQL 14 and earlier.
  */
 #if PG_VERSION_NUM < 150000
 #define set_config_option_ext(name, value, context, source, srole, action, changeVal, \

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -97,9 +97,9 @@
 #endif
 
 /*
- * PostgreSQL 15 Beta3 (commit a2944d8724) introduces the ability to assign
- * permissions to adjust server variables. This adds the call for the new
- * function in PostgreSQL 14 and earlier.
+ * PostgreSQL 15 Beta3 introduces the ability to assign permissions to adjust
+ * server variables. This adds the call for the new function in PostgreSQL 14
+ * and earlier.
  */
 #if PG_VERSION_NUM < 150000
 #define set_config_option_ext(name, value, context, source, srole, action, changeVal, \


### PR DESCRIPTION
The macro definition set_config_option_ext(), protected by the
preprocessor check 'PG_VERSION_NUM < 150000', allows us to build pg_tle
with Postgres versions 15 Beta3 and above, but it does not help when
building with Postgres 15beta2 or earlier.
