### PR TITLE
Removed dead/unreachable return statements

### DIFF
--- a/src/feature.c
+++ b/src/feature.c
@@ -70,7 +70,6 @@ feature_proc(const char *featurename)
 
 		ret = SPI_execute_with_args(query, 1, featargtypes, featargs, NULL, true, 0);
 
-
 		if (ret != SPI_OK_SELECT)
 			ereport(ERROR,
 					errmsg("Unable to query \"%s.%s\"", PG_TLE_NSPNAME, FEATURE_TABLE));

--- a/src/guc-file.l
+++ b/src/guc-file.l
@@ -209,6 +209,14 @@ tleParseConfigFp(FILE *fp, const char *config_file, int depth, int elevel,
 	int			token;
 	const char *cf = NULL;
 
+    /*
+     * Since tleParseConfigFp() is always called with elevel == ERROR, the
+     * ereport(elevel) and elog(elevel) calls will never return. Hence the code
+     * within their respective code blocks that is after those calls is
+     * unreachable. But we keep that code intact to maintain parity with the
+     * upstream Postgres version of this function, where it was copied from.
+     */
+
 	if (fp)
 		cf = config_file;
 


### PR DESCRIPTION
This is in continuation of f8c7e95baf.

Code after ereport(ERROR) and elog(ERROR) calls is unreachable, so
remove such code.

In passing, add or remove blank lines, add curly braces, etc., to
improve readability. This is not a full sweep of the code base, just for
the parts that I was inspecting to look for dead code.
