### PR TITLE
Fix bug preventing TLEs auto-updating on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJS = src/tleextension.o src/guc-file.o src/feature.o src/passcheck.o src/uni_a
 EXTRA_CLEAN	= src/guc-file.c pg_tle.control pg_tle--$(EXTVERSION).sql
 DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql pg_tle--1.0.4--1.0.5.sql
 
-REGRESS = pg_tle_api pg_tle_management pg_tle_injection pg_tle_perms pg_tle_requires pg_tle_datatype
+REGRESS = pg_tle_api pg_tle_management pg_tle_injection pg_tle_perms pg_tle_requires pg_tle_datatype pg_tle_versions
 
 REGRESS_OPTS = --inputdir=test --temp-config ./regress.conf
 

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2215,6 +2215,11 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	Oid	   	   ctlfuncid = InvalidOid;
 	Oid	   	   sqlfuncid = InvalidOid;
 	ExtensionControlFile *pcontrol = NULL;
+	List	       *evi_list;
+	List           *updateVersions;
+	ExtensionVersionInfo *evi_start;
+	ExtensionVersionInfo *evi_target;
+
 
 	/* Determine if this is a pg_tle extnsion rather than a "real" extension */
 	if (strncmp(pstate->p_sourcetext, PG_TLE_MAGIC, sizeof(PG_TLE_MAGIC)) == 0)
@@ -2328,11 +2333,6 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	 * script and all upgrade scripts.
 	 */
 
-	List	   *evi_list;
-	List       *updateVersions;
-	ExtensionVersionInfo *evi_start;
-	ExtensionVersionInfo *evi_target;
-
 	/* Extract the version update graph from the script directory */
 	evi_list = get_ext_ver_list(pcontrol);
 
@@ -2370,11 +2370,12 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 
 		foreach(lcv, updateVersions)
 		{
+			ObjectAddress upgradesqlfunc;
+
 			versionName = (char *) lfirst(lcv);
 			sqlname = psprintf("%s--%s--%s.sql", extname, oldVersionName, versionName);
 			sqlfuncid = get_tlefunc_oid_if_exists(sqlname);
 
-			ObjectAddress upgradesqlfunc;
 			upgradesqlfunc.classId = ProcedureRelationId;
 			upgradesqlfunc.objectId = sqlfuncid;
 			upgradesqlfunc.objectSubId = 0;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2322,11 +2322,36 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	if (ctlfuncid == InvalidOid)
 		elog(ERROR, "could not find control function %s for extension %s in schema %s", quote_identifier(ctlname), quote_identifier(extname), quote_identifier(PG_TLE_NSPNAME));
 
-	sqlname = psprintf("%s--%s.sql", extname, versionName);
-	sqlfuncid = get_tlefunc_oid_if_exists(sqlname);
-	if (sqlfuncid == InvalidOid)
+	/* The sql script for the installed version may not exist if the version was
+	 * installed via an upgrade script. Look for a starting version that does have
+	 * an existing install script, and then record a dependency on the install
+	 * script and all upgrade scripts.
+	 */
+
+	List	   *evi_list;
+	List       *updateVersions;
+	ExtensionVersionInfo *evi_start;
+	ExtensionVersionInfo *evi_target;
+
+	/* Extract the version update graph from the script directory */
+	evi_list = get_ext_ver_list(pcontrol);
+
+	/* Identify the target version */
+	evi_target = get_ext_ver_info(versionName, &evi_list);
+
+	/* Identify best path to reach target */
+	evi_start = find_install_path(evi_list, evi_target, &updateVersions);
+
+	/* Fail if no path ... */
+	if (evi_start == NULL)
 		elog(ERROR, "could not find sql function %s for extension %s in schema %s", quote_identifier(sqlname), quote_identifier(extname), quote_identifier(PG_TLE_NSPNAME));
 
+	/* Otherwise, use the best starting version */
+	versionName = evi_start->name;
+	sqlname = psprintf("%s--%s.sql", extname, versionName);
+	sqlfuncid = get_tlefunc_oid_if_exists(sqlname);
+
+	/* Record dependencies on control function and sql function for base version */
 	ctlfunc.classId = ProcedureRelationId;
 	ctlfunc.objectId = ctlfuncid;
 	ctlfunc.objectSubId = 0;
@@ -2337,6 +2362,26 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 
 	recordDependencyOn(&retobj, &ctlfunc, DEPENDENCY_NORMAL);
 	recordDependencyOn(&retobj, &sqlfunc, DEPENDENCY_NORMAL);
+
+	/* If necessary update scripts are found, record dependency on each script */
+	if (updateVersions != NULL) {
+		const char *oldVersionName = versionName;
+		ListCell   *lcv;
+
+		foreach(lcv, updateVersions)
+		{
+			versionName = (char *) lfirst(lcv);
+			sqlname = psprintf("%s--%s--%s.sql", extname, oldVersionName, versionName);
+			sqlfuncid = get_tlefunc_oid_if_exists(sqlname);
+
+			ObjectAddress upgradesqlfunc;
+			upgradesqlfunc.classId = ProcedureRelationId;
+			upgradesqlfunc.objectId = sqlfuncid;
+			upgradesqlfunc.objectSubId = 0;
+
+			recordDependencyOn(&retobj, &upgradesqlfunc, DEPENDENCY_NORMAL);
+		}
+	}
 
 	/* end pg_tle extensions */
 	UNSET_TLEEXT;
@@ -4327,27 +4372,29 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	/*
 	 * Create the control and sql string returning function
 	 *
-	 * NOTE: we used to build a CREATE OR REPLACE statement here
-	 *       but that would silently replace the control-string
-	 *       function and the sql-string function. We've removed
-	 *       the "OR REPLACE" clause because we now assume that
-	 *       a "duplicate function" error means that the extension
-	 *       has already been installed.
+	 * NOTE: we used to build a CREATE OR REPLACE statement for
+	 *       the sql-string function, but that would silently
+	 *       replace it in case of a "duplicate function" error.
+	 *       We've removed the "OR REPLACE" clause but kept it in
+	 *       the statement for the control-string function to allow
+	 *       installing multiple versions of the same extension.
+	 *       The sql-string statement is executed first to detect
+	 *       whether a duplicate or new version is being installed.
 	 */
 
-	ctlsql = psprintf(
-		"CREATE FUNCTION %s.%s() RETURNS TEXT AS %s"
-		"SELECT %s%s%s%s LANGUAGE SQL",
-			PG_TLE_NSPNAME, quote_identifier(ctlname),
-			PG_TLE_OUTER_STR, PG_TLE_INNER_STR,
-			ctlstr->data,
-			PG_TLE_INNER_STR, PG_TLE_OUTER_STR);
 	sqlsql = psprintf(
 		"CREATE FUNCTION %s.%s() RETURNS TEXT AS %s"
 		"SELECT %s%s%s%s LANGUAGE SQL",
 			PG_TLE_NSPNAME, quote_identifier(sqlname),
 			PG_TLE_OUTER_STR, PG_TLE_INNER_STR,
 			sql_str,
+			PG_TLE_INNER_STR, PG_TLE_OUTER_STR);
+	ctlsql = psprintf(
+		"CREATE OR REPLACE FUNCTION %s.%s() RETURNS TEXT AS %s"
+		"SELECT %s%s%s%s LANGUAGE SQL",
+			PG_TLE_NSPNAME, quote_identifier(ctlname),
+			PG_TLE_OUTER_STR, PG_TLE_INNER_STR,
+			ctlstr->data,
 			PG_TLE_INNER_STR, PG_TLE_OUTER_STR);
 
 	/* flag that we are manipulating pg_tle artifacts */
@@ -4366,16 +4413,16 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	 */
 	PG_TRY();
 	{
-	  /* create the control function */
-	  spi_rc = SPI_exec(ctlsql, 0);
-	  if (spi_rc != SPI_OK_UTILITY) {
-	    elog(ERROR, "failed to install pg_tle extension, %s, control string", extname);
-	  }
-
 	  /* create the sql function */
 	  spi_rc = SPI_exec(sqlsql, 0);
 	  if (spi_rc != SPI_OK_UTILITY) {
 	    elog(ERROR, "failed to install pg_tle extension, %s, sql string", extname);
+	  }
+
+	  /* create the control function */
+	  spi_rc = SPI_exec(ctlsql, 0);
+	  if (spi_rc != SPI_OK_UTILITY) {
+	    elog(ERROR, "failed to install pg_tle extension, %s, control string", extname);
 	  }
 	}
 	PG_CATCH();

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -156,25 +156,6 @@ SELECT CURRENT_USER;
  dbadmin
 (1 row)
 
-SELECT pgtle.install_extension
-(
- 'test123',
- '1.1',
- 'Test TLE Functions',
-$_pgtle_$
-  CREATE OR REPLACE FUNCTION test123_func()
-  RETURNS INT AS $$
-  (
-    SELECT 42
-  )$$ LANGUAGE sql;
-  CREATE OR REPLACE FUNCTION test123_func_2()
-  RETURNS INT AS $$
-  (
-    SELECT 424242
-  )$$ LANGUAGE sql;
-$_pgtle_$
-);
-ERROR:  extension "test123" already installed
 SELECT pgtle.install_update_path
 (
  'test123',

--- a/test/expected/pg_tle_versions.out
+++ b/test/expected/pg_tle_versions.out
@@ -1,0 +1,174 @@
+/*
+*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/*
+* 1. Test that an existing version of an extension cannot be installed again
+* 2. Test that a different version of an installed extension can be installed
+* 3. Test that CREATE EXTENSION automatically updates to default version
+*/
+\pset pager off
+CREATE EXTENSION pg_tle;
+-- install version 1.0 of an extension
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           42
+(1 row)
+
+DROP EXTENSION test123;
+-- an existing version of an extension cannot be installed again
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ERROR:  extension "test123" already installed
+-- but a different version of the same extension can be installed
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.1',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
+-- uninstall version 1.1
+SELECT pgtle.set_default_version('test123', '1.0');
+ set_default_version 
+---------------------
+ t
+(1 row)
+
+SELECT pgtle.uninstall_extension('test123', '1.1');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           42
+(1 row)
+
+SELECT test123_func_2();    -- expect to fail
+ERROR:  function test123_func_2() does not exist
+LINE 1: SELECT test123_func_2();
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DROP EXTENSION test123;
+-- create update path to 1.1 instead
+SELECT pgtle.install_update_path
+(
+ 'test123',
+ '1.0',
+ '1.1',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
+-- if version 1.1 is set as default, then it should be create-able via the upgrade path
+SELECT pgtle.set_default_version('test123', '1.1');
+ set_default_version 
+---------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
+-- sanity check that uninstall works
+SELECT pgtle.uninstall_extension('test123');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+-- clean up
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP ROLE pgtle_admin;

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -117,25 +117,6 @@ SET search_path TO pgtle, public;
 -- installation of artifacts requires semi-privileged role
 SET SESSION AUTHORIZATION dbadmin;
 SELECT CURRENT_USER;
-SELECT pgtle.install_extension
-(
- 'test123',
- '1.1',
- 'Test TLE Functions',
-$_pgtle_$
-  CREATE OR REPLACE FUNCTION test123_func()
-  RETURNS INT AS $$
-  (
-    SELECT 42
-  )$$ LANGUAGE sql;
-  CREATE OR REPLACE FUNCTION test123_func_2()
-  RETURNS INT AS $$
-  (
-    SELECT 424242
-  )$$ LANGUAGE sql;
-$_pgtle_$
-);
-
 SELECT pgtle.install_update_path
 (
  'test123',

--- a/test/sql/pg_tle_versions.sql
+++ b/test/sql/pg_tle_versions.sql
@@ -1,0 +1,114 @@
+/*
+*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+* 1. Test that an existing version of an extension cannot be installed again
+* 2. Test that a different version of an installed extension can be installed
+* 3. Test that CREATE EXTENSION automatically updates to default version
+*/
+
+\pset pager off
+CREATE EXTENSION pg_tle;
+
+-- install version 1.0 of an extension
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+CREATE EXTENSION test123;
+SELECT test123_func();
+DROP EXTENSION test123;
+
+-- an existing version of an extension cannot be installed again
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+-- but a different version of the same extension can be installed
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.1',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+CREATE EXTENSION test123;
+SELECT test123_func();
+SELECT test123_func_2();
+DROP EXTENSION test123;
+
+-- uninstall version 1.1
+SELECT pgtle.set_default_version('test123', '1.0');
+SELECT pgtle.uninstall_extension('test123', '1.1');
+CREATE EXTENSION test123;
+SELECT test123_func();
+SELECT test123_func_2();    -- expect to fail
+DROP EXTENSION test123;
+
+-- create update path to 1.1 instead
+SELECT pgtle.install_update_path
+(
+ 'test123',
+ '1.0',
+ '1.1',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+-- if version 1.1 is set as default, then it should be create-able via the upgrade path
+SELECT pgtle.set_default_version('test123', '1.1');
+CREATE EXTENSION test123;
+SELECT test123_func();
+SELECT test123_func_2();
+DROP EXTENSION test123;
+
+-- sanity check that uninstall works
+SELECT pgtle.uninstall_extension('test123');
+
+-- clean up
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP ROLE pgtle_admin;


### PR DESCRIPTION
Description of changes:

An issue with how pg_tle records dependencies on the control and sql functions prevented TLEs from updating automatically via upgrade scripts to the desired version when created. This commit adds dependencies on the "base" TLE version and each necessary upgrade script.

pg_tle also did not support installing multiple versions of an extension, which has been corrected by adding "OR REPLACE" back to the control-string function (but not the sql-string function). The sql-string is executed first to detect duplicate versions being installed.

fixes #181

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
