### PR TITLE
Implement create_operator_func API.

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -32,6 +32,7 @@
 
 #define TLE_BASE_TYPE_IN         "pg_tle_base_type_in"
 #define TLE_BASE_TYPE_OUT        "pg_tle_base_type_out"
+#define TLE_OPERATOR_FUNC        "pg_tle_operator_func"
 
 /*
  * TLE_BASE_TYPE_SIZE_LIMIT is the maximum allowed size of pg_tle type.

--- a/pg_tle--1.0.5.sql
+++ b/pg_tle--1.0.5.sql
@@ -472,6 +472,38 @@ END;
 $_pgtleie_$
 LANGUAGE plpgsql STRICT;
 
+CREATE FUNCTION pgtle.create_operator_func
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
+)
+RETURNS void
+SET search_path TO 'pgtle'
+STRICT
+AS 'MODULE_PATHNAME', 'pg_tle_create_operator_func'
+LANGUAGE C;
+
+CREATE FUNCTION pgtle.create_operator_func_if_not_exists
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
+)
+RETURNS boolean
+SET search_path TO 'pgtle'
+AS $_pgtleie_$
+BEGIN
+  PERFORM pgtle.create_operator_func(typenamespace, typename, opfunc);
+  RETURN TRUE;
+EXCEPTION
+  -- only catch the duplicate_object exception, let all other exceptions pass through.
+  WHEN duplicate_object THEN
+    RETURN FALSE;
+END;
+$_pgtleie_$
+LANGUAGE plpgsql STRICT;
+
 REVOKE EXECUTE ON FUNCTION pgtle.create_shell_type
 (
   typenamespace regnamespace,
@@ -502,6 +534,20 @@ REVOKE EXECUTE ON FUNCTION pgtle.create_base_type_if_not_exists
   internallength int4
 ) FROM PUBLIC;
 
+REVOKE EXECUTE ON FUNCTION pgtle.create_operator_func
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
+) FROM PUBLIC;
+
+REVOKE EXECUTE ON FUNCTION pgtle.create_operator_func_if_not_exists
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
+) FROM PUBLIC;
+
 GRANT EXECUTE ON FUNCTION pgtle.create_shell_type
 (
   typenamespace regnamespace,
@@ -530,6 +576,20 @@ GRANT EXECUTE ON FUNCTION pgtle.create_base_type_if_not_exists
   infunc regprocedure,
   outfunc regprocedure,
   internallength int4
+) TO pgtle_admin;
+
+GRANT EXECUTE ON FUNCTION pgtle.create_operator_func
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
+) TO pgtle_admin;
+
+GRANT EXECUTE ON FUNCTION pgtle.create_operator_func_if_not_exists
+(
+  typenamespace regnamespace,
+  typename name,
+  opfunc regprocedure
 ) TO pgtle_admin;
 
 CREATE TYPE pgtle.pg_tle_features as ENUM ('passcheck');

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -49,6 +49,9 @@ static Oid	find_user_defined_func(List *procname, bool typeInput);
 static void check_user_defined_func(Oid funcid, Oid typeOid, Oid expectedNamespace, bool typeInput);
 static char *get_probin(Oid fn_oid);
 static List *get_qualified_funcname(Oid fn_oid);
+static void check_user_operator_func(Oid funcid, Oid typeOid, Oid expectedNamespace);
+static void check_pgtle_base_type(Oid typeOid);
+static bool is_pgtle_io_func(Oid funcid, bool typeInput);
 
 static void
 check_is_pgtle_admin(void)
@@ -703,4 +706,272 @@ get_qualified_funcname(Oid funcid)
 							makeString(NameStr(proc->proname)));
 	ReleaseSysCache(tuple);
 	return inputNames;
+}
+
+/*
+ * pgtle_create_operator_func
+ *
+ * User-defined operator funcion accepets BYTEA as argument type (because the custom type
+ * may not be available in some languages such as plrust).
+ *
+ * This function will create a C-version of the operator function that accepts the base type as argument.
+ */
+PG_FUNCTION_INFO_V1(pg_tle_create_operator_func);
+Datum
+pg_tle_create_operator_func(PG_FUNCTION_ARGS)
+{
+	Oid			typeNamespace = PG_GETARG_OID(0);
+	char	   *typeName = NameStr(*PG_GETARG_NAME(1));
+	Oid			funcOid = PG_GETARG_OID(2);
+	Oid			typeOid;
+	int			nargs;
+	Oid		   *argTypes;
+	AclResult	aclresult;
+	char	   *namespaceName;
+
+	/*
+	 * Even though the SQL function is locked down so only a member of
+	 * pgtle_admin can run this function, let's check and make sure there is
+	 * not a way to bypass that
+	 */
+	check_is_pgtle_admin();
+
+	/* Check we have creation rights in target namespace */
+	aclresult = PG_NAMESPACE_ACLCHECK(typeNamespace, GetUserId(), ACL_CREATE);
+	namespaceName = get_namespace_name(typeNamespace);
+	if (aclresult != ACLCHECK_OK)
+		aclcheck_error(aclresult, OBJECT_SCHEMA, namespaceName);
+
+	/*
+	 * Look to see if type already exists
+	 */
+	typeOid = GET_TYPE_OID(TYPENAMENSP,
+						   CStringGetDatum(typeName),
+						   ObjectIdGetDatum(typeNamespace));
+
+	if (!OidIsValid(typeOid))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("type \"%s\" does not exist", typeName)));
+
+	/*
+	 * Check we are the owner of the base type.
+	 */
+	if (!PG_TYPE_OWNERCHECK(typeOid, GetUserId()))
+		aclcheck_error_type(ACLCHECK_NOT_OWNER, typeOid);
+
+	/*
+	 * Check we are the owner of the operator funcion.
+	 */
+	if (!PG_PROC_OWNERCHECK(funcOid, GetUserId()))
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_FUNCTION, get_func_name(funcOid));
+
+	check_user_operator_func(funcOid, typeOid, typeNamespace);
+	check_pgtle_base_type(typeOid);
+
+	/*
+	 * check_user_operator_func already ensures the number of func args is 1
+	 * or 2.
+	 */
+	nargs = get_func_nargs(funcOid);
+	argTypes = (Oid *) palloc(nargs * sizeof(Oid));
+	argTypes[0] = typeOid;
+	if (nargs == 2)
+		argTypes[1] = typeOid;
+
+	create_c_func_internal(typeNamespace, funcOid,
+						   buildoidvector(argTypes, nargs),
+						   get_func_rettype(funcOid), TLE_OPERATOR_FUNC,
+						   get_probin(fcinfo->flinfo->fn_oid));
+	PG_RETURN_BOOL(true);
+}
+
+/*
+ * check_user_operator_func
+ *
+ * Check a user-defined operator function meets pg_tle specific requirements:
+ * 1. must be defined in a trusted language (We check it's not in C or internal for now);
+ * 2. must accept one or two arguments of type bytea;
+ * 3. must be in the same namespace as the base type;
+ * 4. the to-be-created C operator function must not exist yet.
+ *
+ * Raise an error if any requirement is not met.
+ */
+static void
+check_user_operator_func(Oid funcid, Oid typeOid, Oid expectedNamespace)
+{
+	HeapTuple	tuple;
+	Form_pg_proc proc;
+	List	   *funcNameList;
+	Oid		   *argTypes;
+
+	tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for function %u", funcid);
+	proc = (Form_pg_proc) GETSTRUCT(tuple);
+
+	if (proc->prolang == INTERNALlanguageId || proc->prolang == ClanguageId)
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("type operator function cannot be defined in C or internal")));
+	}
+
+	if (!((proc->pronargs == 1 && proc->proargtypes.values[0] == BYTEAOID) ||
+		  (proc->pronargs == 2 && proc->proargtypes.values[0] == BYTEAOID && proc->proargtypes.values[1] == BYTEAOID)))
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("type opeartor function must accept one or two arguments of type bytea")));
+	}
+
+	if (proc->pronamespace != expectedNamespace)
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("type operator functions must exist in the same namespace as the type")));
+	}
+
+	argTypes = (Oid *) palloc(proc->pronargs * sizeof(Oid));
+	argTypes[0] = typeOid;
+	if (proc->pronargs == 2)
+		argTypes[1] = typeOid;
+
+	funcNameList = list_make2(makeString(get_namespace_name(expectedNamespace)),
+							  makeString(NameStr(proc->proname)));
+	if (OidIsValid(LookupFuncName(funcNameList, proc->pronargs, argTypes, true)))
+		ereport(ERROR,
+				(errcode(ERRCODE_DUPLICATE_OBJECT),
+				 errmsg("function \"%s\" already exists", NameListToString(funcNameList))));
+
+	ReleaseSysCache(tuple);
+}
+
+/*
+ * check_pgtle_base_type
+ *
+ * Check whether the input type is a pg_tle base type.
+ * This is done by checking if the I/O functions are created by pg_tle (based on prosrc).
+ */
+static void
+check_pgtle_base_type(Oid typeOid)
+{
+	HeapTuple	tuple;
+	Form_pg_type typeForm;
+	Oid			typeOwner;
+	Oid			inputOid;
+	Oid			outputOid;
+	Oid			tleadminoid;
+
+	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typeOid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for type %u", typeOid);
+	typeForm = (Form_pg_type) GETSTRUCT(tuple);
+
+	if (!typeForm->typisdefined)
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("type %s is only a shell type", format_type_be(typeOid))));
+	}
+
+	tleadminoid = get_role_oid(PG_TLE_ADMIN, false);
+	typeOwner = typeForm->typowner;
+	inputOid = typeForm->typinput;
+	outputOid = typeForm->typoutput;
+	ReleaseSysCache(tuple);
+
+	CHECK_CAN_SET_ROLE(typeOwner, tleadminoid);
+
+	if (!is_pgtle_io_func(inputOid, true) || !is_pgtle_io_func(outputOid, false))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("type %s is not a pg_tle defined base type", format_type_be(typeOid))));
+}
+
+/*
+ * is_pgtle_io_func
+ *
+ * Returns whether a given function is a pg_tle type I/O function.
+ * When `input` is true, the function returns whether a given function is a pg_tle type input function;
+ * otherwise, the function returns whether a given function is a pg_tle type output function.
+ *
+ * A function is considered as pg_tle type I/O function when
+ * 1. It's defined in C language;
+ * 2. prosrc is TLE_BASE_TYPE_IN/TLE_BASE_TYPE_OUT.
+ */
+static bool
+is_pgtle_io_func(Oid funcid, bool typeInput)
+{
+	HeapTuple	tuple;
+	Form_pg_proc proc;
+	Datum		prosrcattr;
+	char	   *prosrcstring;
+	bool		isnull;
+
+	tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for function %u", funcid);
+
+	proc = (Form_pg_proc) GETSTRUCT(tuple);
+	if (proc->prolang != ClanguageId)
+	{
+		ReleaseSysCache(tuple);
+		return false;
+	}
+
+	prosrcattr = SysCacheGetAttr(PROCOID, tuple,
+								 Anum_pg_proc_prosrc, &isnull);
+	Assert(!isnull);
+
+	prosrcstring = TextDatumGetCString(prosrcattr);
+	ReleaseSysCache(tuple);
+	return strcmp(prosrcstring, typeInput ? TLE_BASE_TYPE_IN : TLE_BASE_TYPE_OUT) == 0;
+}
+
+/*
+ * pg_tle_operator_func
+ *
+ * This function is used by pg_tle type operator function. Based on the C operator function,
+ * we can find the corresponding user-defined operator function, and calls the user-defined operator function.
+ */
+PG_FUNCTION_INFO_V1(pg_tle_operator_func);
+Datum
+pg_tle_operator_func(PG_FUNCTION_ARGS)
+{
+	Datum		result;
+	Oid			userFunc;
+	List	   *procname;
+	Oid		   *argtypes = NULL;
+	int			nargs = 0;
+
+	procname = get_qualified_funcname(fcinfo->flinfo->fn_oid);
+	get_func_signature(fcinfo->flinfo->fn_oid, &argtypes, &nargs);
+	if (nargs != 1 && nargs != 2)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("operator function %s must accept one or two arguments",
+						func_signature_string(procname, nargs, NIL, argtypes))));
+
+	argtypes[0] = BYTEAOID;
+	if (nargs == 2)
+		argtypes[1] = BYTEAOID;
+
+	userFunc = LookupFuncName(procname, nargs, argtypes, true);
+	if (!OidIsValid(userFunc))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("function %s does not exist",
+						func_signature_string(procname, nargs, NIL, argtypes))));
+
+	if (nargs == 1)
+		result = OidFunctionCall1Coll(userFunc, InvalidOid, PG_GETARG_DATUM(0));
+	else
+		result = OidFunctionCall2Coll(userFunc, InvalidOid, PG_GETARG_DATUM(0), PG_GETARG_DATUM(1));
+
+	return result;
 }

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -193,9 +193,9 @@ $$ IMMUTABLE STRICT LANGUAGE sql;
 SELECT pgtle.create_operator_func('public', 'test_citext', 'pg_catalog.bttextcmp(text, text)'::regprocedure);
 ERROR:  must be owner of function bttextcmp
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func1(test_citext, test_citext)'::regprocedure);
-ERROR:  type opeartor function must accept one or two arguments of type bytea
+ERROR:  type operator function must accept arguments of bytea
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func2(bytea, bytea, bytea)'::regprocedure);
-ERROR:  type opeartor function must accept one or two arguments of type bytea
+ERROR:  type opeartor function must accept one or two arguments of bytea
 -- create_operator_func fails on duplicate
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
  create_operator_func 

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -343,77 +343,56 @@ SELECT CURRENT_USER;
  dbadmin
 (1 row)
 
+-- Drop user-defined operator functions
+DROP FUNCTION test_citext_cmp(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_cmp(test_citext,test_citext)
+drop cascades to operator class test_citext_ops for access method btree
+DROP FUNCTION test_citext_eq(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_eq(test_citext,test_citext)
+drop cascades to operator =(test_citext,test_citext)
+DROP FUNCTION test_citext_ne(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_ne(test_citext,test_citext)
+drop cascades to operator <>(test_citext,test_citext)
+DROP FUNCTION test_citext_lt(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_lt(test_citext,test_citext)
+drop cascades to operator <(test_citext,test_citext)
+DROP FUNCTION test_citext_le(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_le(test_citext,test_citext)
+drop cascades to operator <=(test_citext,test_citext)
+DROP FUNCTION test_citext_gt(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_gt(test_citext,test_citext)
+drop cascades to operator >(test_citext,test_citext)
+DROP FUNCTION test_citext_ge(bytea, bytea) CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function test_citext_ge(test_citext,test_citext)
+drop cascades to operator >=(test_citext,test_citext)
 -- Drop the user-defined I/O function will dropping the custom type in cascade
 DROP FUNCTION test_citext_in(text);
 ERROR:  cannot drop function test_citext_in(text) because other objects depend on it
 DETAIL:  function test_citext_in(cstring) depends on function test_citext_in(text)
 type test_citext depends on function test_citext_in(cstring)
 function test_citext_out(test_citext) depends on type test_citext
-function test_citext_cmp(test_citext,test_citext) depends on type test_citext
-function test_citext_lt(test_citext,test_citext) depends on type test_citext
-function test_citext_le(test_citext,test_citext) depends on type test_citext
-function test_citext_eq(test_citext,test_citext) depends on type test_citext
-function test_citext_ne(test_citext,test_citext) depends on type test_citext
-function test_citext_gt(test_citext,test_citext) depends on type test_citext
-function test_citext_ge(test_citext,test_citext) depends on type test_citext
-operator >(test_citext,test_citext) depends on type test_citext
-operator >=(test_citext,test_citext) depends on type test_citext
-operator <(test_citext,test_citext) depends on type test_citext
-operator <=(test_citext,test_citext) depends on type test_citext
-operator <>(test_citext,test_citext) depends on type test_citext
-operator =(test_citext,test_citext) depends on type test_citext
-operator class test_citext_ops for access method btree depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_out(bytea);
 ERROR:  cannot drop function test_citext_out(bytea) because other objects depend on it
 DETAIL:  function test_citext_out(test_citext) depends on function test_citext_out(bytea)
 type test_citext depends on function test_citext_out(test_citext)
 function test_citext_in(cstring) depends on type test_citext
-function test_citext_cmp(test_citext,test_citext) depends on type test_citext
-function test_citext_lt(test_citext,test_citext) depends on type test_citext
-function test_citext_le(test_citext,test_citext) depends on type test_citext
-function test_citext_eq(test_citext,test_citext) depends on type test_citext
-function test_citext_ne(test_citext,test_citext) depends on type test_citext
-function test_citext_gt(test_citext,test_citext) depends on type test_citext
-function test_citext_ge(test_citext,test_citext) depends on type test_citext
-operator >(test_citext,test_citext) depends on type test_citext
-operator >=(test_citext,test_citext) depends on type test_citext
-operator <(test_citext,test_citext) depends on type test_citext
-operator <=(test_citext,test_citext) depends on type test_citext
-operator <>(test_citext,test_citext) depends on type test_citext
-operator =(test_citext,test_citext) depends on type test_citext
-operator class test_citext_ops for access method btree depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_in(text) CASCADE;
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function test_citext_in(cstring)
 drop cascades to type test_citext
 drop cascades to function test_citext_out(test_citext)
-drop cascades to function test_citext_cmp(test_citext,test_citext)
-drop cascades to function test_citext_lt(test_citext,test_citext)
-drop cascades to function test_citext_le(test_citext,test_citext)
-drop cascades to function test_citext_eq(test_citext,test_citext)
-drop cascades to function test_citext_ne(test_citext,test_citext)
-drop cascades to function test_citext_gt(test_citext,test_citext)
-drop cascades to function test_citext_ge(test_citext,test_citext)
-drop cascades to operator >(test_citext,test_citext)
-drop cascades to operator >=(test_citext,test_citext)
-drop cascades to operator <(test_citext,test_citext)
-drop cascades to operator <=(test_citext,test_citext)
-drop cascades to operator <>(test_citext,test_citext)
-drop cascades to operator =(test_citext,test_citext)
-drop cascades to operator class test_citext_ops for access method btree
 DROP FUNCTION test_citext_out(bytea) CASCADE;
 DROP TABLE test_dt;
 ERROR:  table "test_dt" does not exist
--- Drop user-defined operator functions
-DROP FUNCTION test_citext_cmp;
-DROP FUNCTION test_citext_eq;
-DROP FUNCTION test_citext_ne;
-DROP FUNCTION test_citext_lt;
-DROP FUNCTION test_citext_le;
-DROP FUNCTION test_citext_gt;
-DROP FUNCTION test_citext_ge;
 -- A fixed length custom type int2: a 2-element vector of one byte integer value
 SELECT pgtle.create_shell_type('public', 'test_int2');
  create_shell_type 

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -133,6 +133,7 @@ SELECT * FROM test_dt;
  
 (1 row)
 
+DROP TABLE test_dt;
 -- create_base_type fails on duplicates
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
 ERROR:  type "test_citext" already exists
@@ -143,29 +144,276 @@ SELECT pgtle.create_base_type_if_not_exists('public', 'test_citext', 'test_citex
  f
 (1 row)
 
+CREATE FUNCTION public.test_citext_cmp(l bytea, r bytea) 
+RETURNS int AS
+$$
+  SELECT pg_catalog.bttextcmp(pg_catalog.lower(pg_catalog.convert_from(l, 'UTF8')), pg_catalog.lower(pg_catalog.convert_from(r, 'UTF8')));
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_lt(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) < 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_eq(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) = 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_le(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) <= 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_gt(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) > 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_ge(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) >= 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.test_citext_ne(l bytea, r bytea) 
+RETURNS boolean AS
+$$
+    SELECT public.test_citext_cmp(l, r) != 0;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.invalid_operator_func1(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+    SELECT 1 = 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE FUNCTION public.invalid_operator_func2(r1 bytea, r2 bytea, r3 bytea) 
+RETURNS boolean AS
+$$
+    SELECT 1 = 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+-- invalid operator func
+SELECT pgtle.create_operator_func('public', 'test_citext', 'pg_catalog.bttextcmp(text, text)'::regprocedure);
+ERROR:  must be owner of function bttextcmp
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func1(test_citext, test_citext)'::regprocedure);
+ERROR:  type opeartor function must accept one or two arguments of type bytea
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func2(bytea, bytea, bytea)'::regprocedure);
+ERROR:  type opeartor function must accept one or two arguments of type bytea
+-- create_operator_func fails on duplicate
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ERROR:  function "public.test_citext_cmp" already exists
+-- create_operator_func returns false on duplicate
+SELECT pgtle.create_operator_func_if_not_exists('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ create_operator_func_if_not_exists 
+------------------------------------
+ f
+(1 row)
+
+DROP FUNCTION invalid_operator_func1;
+DROP FUNCTION invalid_operator_func2;
+DROP FUNCTION test_citext_cmp(test_citext, test_citext);
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_lt(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_le(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_eq(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_ne(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_gt(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_ge(bytea, bytea)'::regprocedure);
+ create_operator_func 
+----------------------
+ 
+(1 row)
+
+CREATE OPERATOR < (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = >,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel,
+    PROCEDURE = public.test_citext_lt
+);
+CREATE OPERATOR <= (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = >=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel,
+    PROCEDURE = public.test_citext_le
+);
+CREATE OPERATOR = (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES,
+    PROCEDURE = public.test_citext_eq
+);
+CREATE OPERATOR <> (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    PROCEDURE = public.test_citext_ne
+);
+CREATE OPERATOR > (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel,
+    PROCEDURE = public.test_citext_gt
+);
+CREATE OPERATOR >= (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel,
+    PROCEDURE = public.test_citext_ge
+);
+RESET SESSION AUTHORIZATION;
+CREATE OPERATOR CLASS public.test_citext_ops
+    DEFAULT FOR TYPE public.test_citext USING btree AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       > ,
+        OPERATOR        5       >= ,
+        FUNCTION        1       public.test_citext_cmp(public.test_citext, public.test_citext);
+-- Regular user can use the newly created type
+SET SESSION AUTHORIZATION dbstaff;
+SELECT CURRENT_USER;
+ current_user 
+--------------
+ dbstaff
+(1 row)
+
+CREATE TABLE public.test_dt(c1 test_citext PRIMARY KEY);
+INSERT INTO test_dt VALUES ('SELECT'), ('INSERT'), ('UPDATE'), ('DELETE');
+INSERT INTO test_dt VALUES ('select');
+ERROR:  duplicate key value violates unique constraint "test_dt_pkey"
+DETAIL:  Key (c1)=(select) already exists.
+DROP TABLE test_dt;
+SET SESSION AUTHORIZATION dbadmin;
+SELECT CURRENT_USER;
+ current_user 
+--------------
+ dbadmin
+(1 row)
+
 -- Drop the user-defined I/O function will dropping the custom type in cascade
 DROP FUNCTION test_citext_in(text);
 ERROR:  cannot drop function test_citext_in(text) because other objects depend on it
 DETAIL:  function test_citext_in(cstring) depends on function test_citext_in(text)
 type test_citext depends on function test_citext_in(cstring)
 function test_citext_out(test_citext) depends on type test_citext
-column c1 of table test_dt depends on type test_citext
+function test_citext_cmp(test_citext,test_citext) depends on type test_citext
+function test_citext_lt(test_citext,test_citext) depends on type test_citext
+function test_citext_le(test_citext,test_citext) depends on type test_citext
+function test_citext_eq(test_citext,test_citext) depends on type test_citext
+function test_citext_ne(test_citext,test_citext) depends on type test_citext
+function test_citext_gt(test_citext,test_citext) depends on type test_citext
+function test_citext_ge(test_citext,test_citext) depends on type test_citext
+operator >(test_citext,test_citext) depends on type test_citext
+operator >=(test_citext,test_citext) depends on type test_citext
+operator <(test_citext,test_citext) depends on type test_citext
+operator <=(test_citext,test_citext) depends on type test_citext
+operator <>(test_citext,test_citext) depends on type test_citext
+operator =(test_citext,test_citext) depends on type test_citext
+operator class test_citext_ops for access method btree depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_out(bytea);
 ERROR:  cannot drop function test_citext_out(bytea) because other objects depend on it
 DETAIL:  function test_citext_out(test_citext) depends on function test_citext_out(bytea)
 type test_citext depends on function test_citext_out(test_citext)
 function test_citext_in(cstring) depends on type test_citext
-column c1 of table test_dt depends on type test_citext
+function test_citext_cmp(test_citext,test_citext) depends on type test_citext
+function test_citext_lt(test_citext,test_citext) depends on type test_citext
+function test_citext_le(test_citext,test_citext) depends on type test_citext
+function test_citext_eq(test_citext,test_citext) depends on type test_citext
+function test_citext_ne(test_citext,test_citext) depends on type test_citext
+function test_citext_gt(test_citext,test_citext) depends on type test_citext
+function test_citext_ge(test_citext,test_citext) depends on type test_citext
+operator >(test_citext,test_citext) depends on type test_citext
+operator >=(test_citext,test_citext) depends on type test_citext
+operator <(test_citext,test_citext) depends on type test_citext
+operator <=(test_citext,test_citext) depends on type test_citext
+operator <>(test_citext,test_citext) depends on type test_citext
+operator =(test_citext,test_citext) depends on type test_citext
+operator class test_citext_ops for access method btree depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_in(text) CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to function test_citext_in(cstring)
 drop cascades to type test_citext
 drop cascades to function test_citext_out(test_citext)
-drop cascades to column c1 of table test_dt
+drop cascades to function test_citext_cmp(test_citext,test_citext)
+drop cascades to function test_citext_lt(test_citext,test_citext)
+drop cascades to function test_citext_le(test_citext,test_citext)
+drop cascades to function test_citext_eq(test_citext,test_citext)
+drop cascades to function test_citext_ne(test_citext,test_citext)
+drop cascades to function test_citext_gt(test_citext,test_citext)
+drop cascades to function test_citext_ge(test_citext,test_citext)
+drop cascades to operator >(test_citext,test_citext)
+drop cascades to operator >=(test_citext,test_citext)
+drop cascades to operator <(test_citext,test_citext)
+drop cascades to operator <=(test_citext,test_citext)
+drop cascades to operator <>(test_citext,test_citext)
+drop cascades to operator =(test_citext,test_citext)
+drop cascades to operator class test_citext_ops for access method btree
 DROP FUNCTION test_citext_out(bytea) CASCADE;
 DROP TABLE test_dt;
+ERROR:  table "test_dt" does not exist
+-- Drop user-defined operator functions
+DROP FUNCTION test_citext_cmp;
+DROP FUNCTION test_citext_eq;
+DROP FUNCTION test_citext_ne;
+DROP FUNCTION test_citext_lt;
+DROP FUNCTION test_citext_le;
+DROP FUNCTION test_citext_gt;
+DROP FUNCTION test_citext_ge;
 -- A fixed length custom type int2: a 2-element vector of one byte integer value
 SELECT pgtle.create_shell_type('public', 'test_int2');
  create_shell_type 

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -10,8 +10,17 @@ CREATE ROLE dbadmin;
 GRANT pgtle_admin TO dbadmin;
 -- create unprivileged role to create trusted extensions
 CREATE ROLE dbstaff;
-GRANT CREATE, USAGE ON SCHEMA PUBLIC TO pgtle_admin;
+-- test roles: 
+-- dbuser1 has pgtle_admin privilege but no CREATE on SCHEMA PUBLIC
+-- dbuser2 has pgtle_admin privilege
+CREATE ROLE dbuser1;
+CREATE ROLE dbuser2;
+GRANT pgtle_admin TO dbuser1;
+GRANT pgtle_admin TO dbuser2;
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbadmin;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbstaff;
+GRANT USAGE ON SCHEMA PUBLIC TO dbuser1;
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser2;
 SET search_path TO pgtle,public;
 -- unprivileged role cannot execute pgtle.create_shell_type and create_shell_type_if_not_exists
 SET SESSION AUTHORIZATION dbstaff;
@@ -189,13 +198,27 @@ RETURNS boolean AS
 $$
     SELECT 1 = 1;
 $$ IMMUTABLE STRICT LANGUAGE sql;
--- invalid operator func
+-- not owner of the operator function
 SELECT pgtle.create_operator_func('public', 'test_citext', 'pg_catalog.bttextcmp(text, text)'::regprocedure);
 ERROR:  must be owner of function bttextcmp
+-- wrong operator funcion arguments
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func1(test_citext, test_citext)'::regprocedure);
 ERROR:  type operator function must accept arguments of bytea
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func2(bytea, bytea, bytea)'::regprocedure);
 ERROR:  type opeartor function must accept one or two arguments of bytea
+-- unprivileged role cannot run create_operator_func
+SET SESSION AUTHORIZATION dbstaff;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ERROR:  permission denied for function create_operator_func
+-- no CREATE priviliege in the namespace
+SET SESSION AUTHORIZATION dbuser1;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ERROR:  permission denied for schema public
+-- not owner of the base type
+SET SESSION AUTHORIZATION dbuser2;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+ERROR:  must be owner of type public.test_citext
+SET SESSION AUTHORIZATION dbadmin;
 -- create_operator_func fails on duplicate
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
  create_operator_func 
@@ -453,10 +476,14 @@ DROP FUNCTION test_int2_out(bytea) CASCADE;
 DROP TABLE test_dt;
 -- clean up
 RESET SESSION AUTHORIZATION;
-REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM pgtle_admin;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbadmin;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbstaff;
+REVOKE USAGE ON SCHEMA PUBLIC FROM dbuser1;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser2;
 DROP ROLE dbstaff;
 DROP ROLE dbadmin;
+DROP ROLE dbuser1;
+DROP ROLE dbuser2;
 DROP EXTENSION pg_tle;
 DROP SCHEMA pgtle;
 DROP ROLE pgtle_admin;

--- a/test/sql/pg_tle_datatype.sql
+++ b/test/sql/pg_tle_datatype.sql
@@ -246,21 +246,21 @@ DROP TABLE test_dt;
 SET SESSION AUTHORIZATION dbadmin;
 SELECT CURRENT_USER;
 
+-- Drop user-defined operator functions
+DROP FUNCTION test_citext_cmp(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_eq(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_ne(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_lt(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_le(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_gt(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_ge(bytea, bytea) CASCADE;
+
 -- Drop the user-defined I/O function will dropping the custom type in cascade
 DROP FUNCTION test_citext_in(text);
 DROP FUNCTION test_citext_out(bytea);
 DROP FUNCTION test_citext_in(text) CASCADE;
 DROP FUNCTION test_citext_out(bytea) CASCADE;
 DROP TABLE test_dt;
-
--- Drop user-defined operator functions
-DROP FUNCTION test_citext_cmp;
-DROP FUNCTION test_citext_eq;
-DROP FUNCTION test_citext_ne;
-DROP FUNCTION test_citext_lt;
-DROP FUNCTION test_citext_le;
-DROP FUNCTION test_citext_gt;
-DROP FUNCTION test_citext_ge;
 
 -- A fixed length custom type int2: a 2-element vector of one byte integer value
 SELECT pgtle.create_shell_type('public', 'test_int2');

--- a/test/sql/pg_tle_datatype.sql
+++ b/test/sql/pg_tle_datatype.sql
@@ -14,8 +14,18 @@ GRANT pgtle_admin TO dbadmin;
 -- create unprivileged role to create trusted extensions
 CREATE ROLE dbstaff;
 
-GRANT CREATE, USAGE ON SCHEMA PUBLIC TO pgtle_admin;
+-- test roles: 
+-- dbuser1 has pgtle_admin privilege but no CREATE on SCHEMA PUBLIC
+-- dbuser2 has pgtle_admin privilege
+CREATE ROLE dbuser1;
+CREATE ROLE dbuser2;
+GRANT pgtle_admin TO dbuser1;
+GRANT pgtle_admin TO dbuser2;
+
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbadmin;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbstaff;
+GRANT USAGE ON SCHEMA PUBLIC TO dbuser1;
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser2;
 SET search_path TO pgtle,public;
 
 -- unprivileged role cannot execute pgtle.create_shell_type and create_shell_type_if_not_exists
@@ -139,11 +149,22 @@ $$
     SELECT 1 = 1;
 $$ IMMUTABLE STRICT LANGUAGE sql;
 
--- invalid operator func
+-- not owner of the operator function
 SELECT pgtle.create_operator_func('public', 'test_citext', 'pg_catalog.bttextcmp(text, text)'::regprocedure);
+-- wrong operator funcion arguments
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func1(test_citext, test_citext)'::regprocedure);
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.invalid_operator_func2(bytea, bytea, bytea)'::regprocedure);
+-- unprivileged role cannot run create_operator_func
+SET SESSION AUTHORIZATION dbstaff;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+-- no CREATE priviliege in the namespace
+SET SESSION AUTHORIZATION dbuser1;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
+-- not owner of the base type
+SET SESSION AUTHORIZATION dbuser2;
+SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
 
+SET SESSION AUTHORIZATION dbadmin;
 -- create_operator_func fails on duplicate
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
@@ -302,10 +323,14 @@ DROP TABLE test_dt;
 
 -- clean up
 RESET SESSION AUTHORIZATION;
-REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM pgtle_admin;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbadmin;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbstaff;
+REVOKE USAGE ON SCHEMA PUBLIC FROM dbuser1;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser2;
 DROP ROLE dbstaff;
 DROP ROLE dbadmin;
+DROP ROLE dbuser1;
+DROP ROLE dbuser2;
 DROP EXTENSION pg_tle;
 DROP SCHEMA pgtle;
 DROP ROLE pgtle_admin;


### PR DESCRIPTION
pgtle_admin can run `create_operator_func` to create operator funcs for base types created in pg_tle (by `create_base_type`).

User-defined operator function must accept one or two arguments of BYTEA, we make an C-version operator function that accepts base type as the argument; inside the C-version operator function, we find the user-defined operator function and execute it.

Notes:
1. `create_operator_func` is not strictly necessary to define an operator function on the base type; however, it will be required for languages such as plrust, because the custom base type is not available in plrust;
2. `CREATE OPERATOR CLASS` requires superuser privileges in pg_tle, but should be already supported in AWS RDS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
