### PR TITLE
Fix a bug that rollback a failed transaction causes server crash.

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -3977,6 +3977,27 @@ _PU_HOOK
 	Oid		tleExtensionOid;
 
 	/*
+	 * Explicitly skip TransactionStmts before calling get_extension_oid().
+	 *
+	 * In an aborted transaction, TransactionStmts (e.g. ROLLBACK) will still
+	 * be passed to process utility hooks. However, relcache lookup must be
+	 * done in a transaction state. Because we don't handle TransactionStmts
+	 * in this hook anyway, TransactionStmts can be skipped.
+	 */
+	if (pu_parsetree && IsA(pu_parsetree, TransactionStmt))
+	{
+		if (prev_hook)
+		{
+			_prev_hook;
+		}
+		else
+		{
+			_standard_ProcessUtility;
+		}
+		return;
+	}
+
+	/*
 	 * We should only execute this hook if the pg_tle extension is installed.
 	 */
 	tleExtensionOid = get_extension_oid(PG_TLE_EXTNAME, true);

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -815,6 +815,18 @@ SELECT pgtle.available_extension_versions();
 ------------------------------
 (0 rows)
 
+-- Skip TransactionStmts
+BEGIN;
+SELECT pgtle.available_extension_versions();
+ available_extension_versions 
+------------------------------
+(0 rows)
+
+SELECT 1/0;
+ERROR:  division by zero
+SELECT pgtle.available_extension_versions();
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
 -- clean up
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION superuser_only();

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -531,6 +531,13 @@ SELECT pgtle.uninstall_extension('test42');
 
 SELECT pgtle.available_extension_versions();
 
+-- Skip TransactionStmts
+BEGIN;
+SELECT pgtle.available_extension_versions();
+SELECT 1/0;
+SELECT pgtle.available_extension_versions();
+ROLLBACK;
+
 -- clean up
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION superuser_only();


### PR DESCRIPTION
Fix issue #208 

The root cause of the crash is when the transaction fails, it's set to aborted state; get_extension_oid function needs a relcache lookup which must be done in a transaction state.

This change fixes this issue by skipping TransactionStmts in process utility hook.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
