### PR TITLE
Fix segfault when creating explicit TLE version

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2303,10 +2303,10 @@ tleCreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	 * based on extension name and version
 	 */
 	extname = stmt->extname;
+	pcontrol = read_extension_control_file(extname);
 
 	if (versionName == NULL)
 	{
-		pcontrol = read_extension_control_file(extname);
 		if (pcontrol->default_version)
 			versionName = pcontrol->default_version;
 		else

--- a/test/expected/pg_tle_versions.out
+++ b/test/expected/pg_tle_versions.out
@@ -6,7 +6,9 @@
 /*
 * 1. Test that an existing version of an extension cannot be installed again
 * 2. Test that a different version of an installed extension can be installed
-* 3. Test that CREATE EXTENSION automatically updates to default version
+* 3. Test that CREATE EXTENSION with an explicit version automatically updates
+*    to that version
+* 4. Test that CREATE EXTENSION automatically updates to default version
 */
 \pset pager off
 CREATE EXTENSION pg_tle;
@@ -140,6 +142,21 @@ $_pgtle_$
  t
 (1 row)
 
+-- test that CREATE EXTENSION version 1.1 works
+CREATE EXTENSION test123 version '1.1';
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
 -- if version 1.1 is set as default, then it should be create-able via the upgrade path
 SELECT pgtle.set_default_version('test123', '1.1');
  set_default_version 

--- a/test/sql/pg_tle_versions.sql
+++ b/test/sql/pg_tle_versions.sql
@@ -7,7 +7,9 @@
 /*
 * 1. Test that an existing version of an extension cannot be installed again
 * 2. Test that a different version of an installed extension can be installed
-* 3. Test that CREATE EXTENSION automatically updates to default version
+* 3. Test that CREATE EXTENSION with an explicit version automatically updates
+*    to that version
+* 4. Test that CREATE EXTENSION automatically updates to default version
 */
 
 \pset pager off
@@ -97,6 +99,12 @@ $_pgtle_$
   )$$ LANGUAGE sql;
 $_pgtle_$
 );
+
+-- test that CREATE EXTENSION version 1.1 works
+CREATE EXTENSION test123 version '1.1';
+SELECT test123_func();
+SELECT test123_func_2();
+DROP EXTENSION test123;
 
 -- if version 1.1 is set as default, then it should be create-able via the upgrade path
 SELECT pgtle.set_default_version('test123', '1.1');


### PR DESCRIPTION
Description of changes:

When recording TLE dependencies for pg_dump/restore, read the extension control file whether an explicit version is specified or not.

fixes #181

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
