### PR TITLE
Fix typo in `pg_dump`/`pg_restore` TAP test

### DIFF
--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -219,12 +219,12 @@ like  ($stdout, qr/1/, 'select_tle_function_from_restored_db_2');
 
 # 3. Verify custom data type
 
-$node->psql($testdb, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
+$node->psql($restored_db, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/TEST/, 'select_custom_data_type_from_restored_db');
 
 # 4. Verify custom data operator
 
-$node->psql($testdb, 'SELECT (c1 = c1) as c2 from test_dt', stdout => \$stdout, stderr => \$stderr);
+$node->psql($restored_db, 'SELECT (c1 = c1) as c2 from test_dt', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/t/, 'operator_from_restored_db');
 
 # Test complete


### PR DESCRIPTION
Description of changes:

Update the post-`pg_restore` checks to point to the restored database instead of the original database.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.