### PR TITLE
Create explicit cast from custom data type to bytea.

### DIFF
--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -22,7 +22,6 @@
 #include "catalog/genbki.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_cast.h"
-#include "catalog/pg_cast_d.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -362,12 +362,12 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 }
 #endif
 
-#if (PG_VERSION_NUM < 160000)
-#define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
-	CastCreate(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior)
-#else
+#if (PG_VERSION_NUM >= 160000)
 #define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
 	CastCreate(sourcetypeid, targettypeid, funcid, InvalidOid, InvalidOid, castcontext, castmethod, behavior)
+#else
+#define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
+	CastCreate(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior)
 #endif
 
 #if PG_VERSION_NUM >= 140000

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -12,9 +12,24 @@
 #ifndef SET_USER_COMPAT_H
 #define SET_USER_COMPAT_H
 
+#include "access/htup_details.h"
+#if PG_VERSION_NUM >= 120000
+#include "access/table.h"
+#endif
+#include "catalog/catalog.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/genbki.h"
+#include "catalog/objectaccess.h"
+#include "catalog/pg_cast.h"
+#include "catalog/pg_cast_d.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
 #include "tcop/utility.h"
+#include "utils/builtins.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
 
 /*
  * PostgreSQL version 14+
@@ -245,6 +260,115 @@
 #define ereport(elevel, ...)	\
 	ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
 	
+#endif
+
+#if PG_VERSION_NUM < 130000
+/*
+ * ----------------------------------------------------------------
+ *		CastCreate
+ *
+ * Forms and inserts catalog tuples for a new cast being created.
+ * Caller must have already checked privileges, and done consistency
+ * checks on the given datatypes and cast function (if applicable).
+ *
+ * 'behavior' indicates the types of the dependencies that the new
+ * cast will have on its input and output types and the cast function.
+ * ----------------------------------------------------------------
+ */
+inline ObjectAddress
+CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
+		   char castmethod, DependencyType behavior)
+{
+	Relation	relation;
+	HeapTuple	tuple;
+	Oid			castid;
+	Datum		values[Natts_pg_cast];
+	bool		nulls[Natts_pg_cast];
+	ObjectAddress myself,
+				referenced;
+	ObjectAddresses *addrs;
+
+	relation = table_open(CastRelationId, RowExclusiveLock);
+
+	/*
+	 * Check for duplicate.  This is just to give a friendly error message,
+	 * the unique index would catch it anyway (so no need to sweat about race
+	 * conditions).
+	 */
+	tuple = SearchSysCache2(CASTSOURCETARGET,
+							ObjectIdGetDatum(sourcetypeid),
+							ObjectIdGetDatum(targettypeid));
+	if (HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_DUPLICATE_OBJECT),
+				 errmsg("cast from type %s to type %s already exists",
+						format_type_be(sourcetypeid),
+						format_type_be(targettypeid))));
+
+	/* ready to go */
+#if PG_VERSION_NUM >= 120000
+	castid = GetNewOidWithIndex(relation, CastOidIndexId, Anum_pg_cast_oid);
+	values[Anum_pg_cast_oid - 1] = ObjectIdGetDatum(castid);
+#endif
+	values[Anum_pg_cast_castsource - 1] = ObjectIdGetDatum(sourcetypeid);
+	values[Anum_pg_cast_casttarget - 1] = ObjectIdGetDatum(targettypeid);
+	values[Anum_pg_cast_castfunc - 1] = ObjectIdGetDatum(funcid);
+	values[Anum_pg_cast_castcontext - 1] = CharGetDatum(castcontext);
+	values[Anum_pg_cast_castmethod - 1] = CharGetDatum(castmethod);
+
+	MemSet(nulls, false, sizeof(nulls));
+
+	tuple = heap_form_tuple(RelationGetDescr(relation), values, nulls);
+
+#if PG_VERSION_NUM >= 120000
+	CatalogTupleInsert(relation, tuple);
+#else
+	castid = CatalogTupleInsert(relation, tuple);
+#endif
+
+	addrs = new_object_addresses();
+
+	/* make dependency entries */
+	ObjectAddressSet(myself, CastRelationId, castid);
+
+	/* dependency on source type */
+	ObjectAddressSet(referenced, TypeRelationId, sourcetypeid);
+	add_exact_object_address(&referenced, addrs);
+
+	/* dependency on target type */
+	ObjectAddressSet(referenced, TypeRelationId, targettypeid);
+	add_exact_object_address(&referenced, addrs);
+
+	/* dependency on function */
+	if (OidIsValid(funcid))
+	{
+		ObjectAddressSet(referenced, ProcedureRelationId, funcid);
+		add_exact_object_address(&referenced, addrs);
+	}
+
+	record_object_address_dependencies(&myself, addrs, behavior);
+	free_object_addresses(addrs);
+
+	/* dependency on extension */
+	recordDependencyOnCurrentExtension(&myself, false);
+
+	/* Post creation hook for new cast */
+	InvokeObjectPostCreateHook(CastRelationId, castid, 0);
+
+	heap_freetuple(tuple);
+
+	table_close(relation, RowExclusiveLock);
+
+	return myself;
+}
+#endif
+
+#if (PG_VERSION_NUM < 160000)
+#define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
+	CastCreate(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior)
+#else
+#define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
+	CastCreate(sourcetypeid, targettypeid, funcid, InvalidOid, InvalidOid, castcontext, castmethod, behavior)
 #endif
 
 #if PG_VERSION_NUM >= 140000

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -20,6 +20,7 @@
 #include "access/htup_details.h"
 #include "access/xact.h"
 #include "catalog/pg_authid.h"
+#include "catalog/pg_cast.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
@@ -368,6 +369,9 @@ pg_tle_create_base_type(PG_FUNCTION_ARGS)
 				InvalidOid);	/* type's collation */
 
 	pfree(array_type);
+
+	/* Create explicit cast from the base type to bytea */
+	CAST_CREATE(typeOid, BYTEAOID, InvalidOid, 'e', 'b', DEPENDENCY_NORMAL);
 
 	PG_RETURN_VOID();
 }

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -371,7 +371,7 @@ pg_tle_create_base_type(PG_FUNCTION_ARGS)
 	pfree(array_type);
 
 	/* Create explicit cast from the base type to bytea */
-	CAST_CREATE(typeOid, BYTEAOID, InvalidOid, 'e', 'b', DEPENDENCY_NORMAL);
+	CAST_CREATE(typeOid, BYTEAOID, InvalidOid, COERCION_CODE_EXPLICIT, COERCION_METHOD_BINARY, DEPENDENCY_NORMAL);
 
 	PG_RETURN_VOID();
 }

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -366,56 +366,198 @@ SELECT CURRENT_USER;
  dbadmin
 (1 row)
 
+-- Drop C-version operator functions cascades to operator class
+DROP FUNCTION test_citext_cmp(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator class test_citext_ops for access method btree
+DROP FUNCTION test_citext_eq(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator =(test_citext,test_citext)
+DROP FUNCTION test_citext_ne(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <>(test_citext,test_citext)
+DROP FUNCTION test_citext_lt(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <(test_citext,test_citext)
+DROP FUNCTION test_citext_le(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <=(test_citext,test_citext)
+DROP FUNCTION test_citext_gt(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator >(test_citext,test_citext)
+DROP FUNCTION test_citext_ge(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator >=(test_citext,test_citext)
+-- Use explicit cast to create operator functions
+CREATE FUNCTION public.test_citext_cmp(l test_citext, r test_citext) 
+RETURNS int AS
+$$
+BEGIN
+  RETURN public.test_citext_cmp(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_eq(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_eq(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_ne(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_ne(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_lt(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_lt(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_le(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_le(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_gt(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_gt(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE FUNCTION public.test_citext_ge(l test_citext, r test_citext) 
+RETURNS boolean AS
+$$
+BEGIN
+  RETURN public.test_citext_ge(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+CREATE OPERATOR < (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = >,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel,
+    PROCEDURE = public.test_citext_lt
+);
+CREATE OPERATOR <= (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = >=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel,
+    PROCEDURE = public.test_citext_le
+);
+CREATE OPERATOR = (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES,
+    PROCEDURE = public.test_citext_eq
+);
+CREATE OPERATOR <> (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    PROCEDURE = public.test_citext_ne
+);
+CREATE OPERATOR > (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel,
+    PROCEDURE = public.test_citext_gt
+);
+CREATE OPERATOR >= (
+    LEFTARG = public.test_citext,
+    RIGHTARG = public.test_citext,
+    COMMUTATOR = <=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel,
+    PROCEDURE = public.test_citext_ge
+);
+RESET SESSION AUTHORIZATION;
+CREATE OPERATOR CLASS public.test_citext_ops
+    DEFAULT FOR TYPE public.test_citext USING btree AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       > ,
+        OPERATOR        5       >= ,
+        FUNCTION        1       public.test_citext_cmp(public.test_citext, public.test_citext);
+SET SESSION AUTHORIZATION dbadmin;
+SELECT CURRENT_USER;
+ current_user 
+--------------
+ dbadmin
+(1 row)
+
+CREATE TABLE public.test_dt(c1 test_citext PRIMARY KEY);
+INSERT INTO test_dt VALUES ('SELECT'), ('INSERT'), ('UPDATE'), ('DELETE');
+INSERT INTO test_dt VALUES ('select');
+ERROR:  duplicate key value violates unique constraint "test_dt_pkey"
+DETAIL:  Key (c1)=(select) already exists.
 -- Drop user-defined operator functions
 DROP FUNCTION test_citext_cmp(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_cmp(test_citext,test_citext)
-drop cascades to operator class test_citext_ops for access method btree
 DROP FUNCTION test_citext_eq(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_eq(test_citext,test_citext)
-drop cascades to operator =(test_citext,test_citext)
 DROP FUNCTION test_citext_ne(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_ne(test_citext,test_citext)
-drop cascades to operator <>(test_citext,test_citext)
 DROP FUNCTION test_citext_lt(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_lt(test_citext,test_citext)
-drop cascades to operator <(test_citext,test_citext)
 DROP FUNCTION test_citext_le(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_le(test_citext,test_citext)
-drop cascades to operator <=(test_citext,test_citext)
 DROP FUNCTION test_citext_gt(bytea, bytea) CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_gt(test_citext,test_citext)
-drop cascades to operator >(test_citext,test_citext)
 DROP FUNCTION test_citext_ge(bytea, bytea) CASCADE;
+DROP FUNCTION test_citext_cmp(test_citext, test_citext) CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to function test_citext_ge(test_citext,test_citext)
-drop cascades to operator >=(test_citext,test_citext)
+DETAIL:  drop cascades to operator class test_citext_ops for access method btree
+drop cascades to constraint test_dt_pkey on table test_dt
+DROP FUNCTION test_citext_eq(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator =(test_citext,test_citext)
+DROP FUNCTION test_citext_ne(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <>(test_citext,test_citext)
+DROP FUNCTION test_citext_lt(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <(test_citext,test_citext)
+DROP FUNCTION test_citext_le(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator <=(test_citext,test_citext)
+DROP FUNCTION test_citext_gt(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator >(test_citext,test_citext)
+DROP FUNCTION test_citext_ge(test_citext, test_citext) CASCADE;
+NOTICE:  drop cascades to operator >=(test_citext,test_citext)
 -- Drop the user-defined I/O function will dropping the custom type in cascade
 DROP FUNCTION test_citext_in(text);
 ERROR:  cannot drop function test_citext_in(text) because other objects depend on it
 DETAIL:  function test_citext_in(cstring) depends on function test_citext_in(text)
 type test_citext depends on function test_citext_in(cstring)
 function test_citext_out(test_citext) depends on type test_citext
+cast from test_citext to bytea depends on type test_citext
+column c1 of table test_dt depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_out(bytea);
 ERROR:  cannot drop function test_citext_out(bytea) because other objects depend on it
 DETAIL:  function test_citext_out(test_citext) depends on function test_citext_out(bytea)
 type test_citext depends on function test_citext_out(test_citext)
 function test_citext_in(cstring) depends on type test_citext
+cast from test_citext to bytea depends on type test_citext
+column c1 of table test_dt depends on type test_citext
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP FUNCTION test_citext_in(text) CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function test_citext_in(cstring)
 drop cascades to type test_citext
 drop cascades to function test_citext_out(test_citext)
+drop cascades to cast from test_citext to bytea
+drop cascades to column c1 of table test_dt
 DROP FUNCTION test_citext_out(bytea) CASCADE;
 DROP TABLE test_dt;
-ERROR:  table "test_dt" does not exist
 -- A fixed length custom type int2: a 2-element vector of one byte integer value
 SELECT pgtle.create_shell_type('public', 'test_int2');
  create_shell_type 
@@ -448,6 +590,21 @@ SELECT pgtle.create_base_type('public', 'test_int2', 'test_int2_in(text)'::regpr
  
 (1 row)
 
+CREATE TABLE test_cast(c1 bytea);
+-- Implicit cast from test_int2 to bytea is allowed.
+INSERT INTO test_cast(c1) VALUES ('11,22'::test_int2);
+ERROR:  column "c1" is of type bytea but expression is of type test_int2
+LINE 1: INSERT INTO test_cast(c1) VALUES ('11,22'::test_int2);
+                                          ^
+HINT:  You will need to rewrite or cast the expression.
+-- Explicit cast from test_int2 to bytea is allowed.
+INSERT INTO test_cast(c1) VALUES (CAST('11,22'::test_int2 AS bytea));
+-- Explicit cast from bytea to test_int2 is not allowed.
+SELECT CAST('\x0b16'::bytea AS test_int2);
+ERROR:  cannot cast type bytea to test_int2
+LINE 1: SELECT CAST('\x0b16'::bytea AS test_int2);
+               ^
+DROP TABLE test_cast;
 CREATE TABLE test_dt(c1 test_int2);
 -- Insert a regular value
 INSERT INTO test_dt VALUES ('11,22');
@@ -467,10 +624,11 @@ SELECT * FROM test_dt;
 (1 row)
 
 DROP FUNCTION test_int2_in(text) CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function test_int2_in(cstring)
 drop cascades to type test_int2
 drop cascades to function test_int2_out(test_int2)
+drop cascades to cast from test_int2 to bytea
 drop cascades to column c1 of table test_dt
 DROP FUNCTION test_int2_out(bytea) CASCADE;
 DROP TABLE test_dt;


### PR DESCRIPTION
Every custom data type is stored as bytea, so the conversion to bytea is always valid. But bytea to custom data type may not be always valid.

This can help users to process the new data type, as they can utilize helper functions defined on bytea.

Defined a function `CastCreate` in compatibility.h for version < 130000 because it is only introduced after pg13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
