### PR TITLE
Require type I/O function to be immutable and strict.

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -33,6 +33,8 @@
 #define TLE_BASE_TYPE_IN         "pg_tle_base_type_in"
 #define TLE_BASE_TYPE_OUT        "pg_tle_base_type_out"
 #define TLE_OPERATOR_FUNC        "pg_tle_operator_func"
+#define TLE_INPUT_FUNC_STR       "input"
+#define TLE_OUTPUT_FUNC_STR      "output"
 
 /*
  * TLE_BASE_TYPE_SIZE_LIMIT is the maximum allowed size of pg_tle type.

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -416,7 +416,7 @@ find_user_defined_func(List *procname, bool typeInput)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				 errmsg("type %s function %s must return type %s",
-						funcType, NameListToString(procname), format_type_be(BYTEAOID))));
+						funcType, NameListToString(procname), format_type_be(expectedRetType))));
 
 	return procOid;
 }

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -388,7 +388,7 @@ find_user_defined_func(List *procname, bool typeInput)
 {
 	Oid			argList[1];
 	Oid			procOid;
-	Oid			expectedRetType;	
+	Oid			expectedRetType;
 	char	   *funcType;
 
 	/*
@@ -408,9 +408,9 @@ find_user_defined_func(List *procname, bool typeInput)
 				 errmsg("function %s does not exist",
 						func_signature_string(procname, 1, NIL, argList))));
 
-	/* 
-	 * User-defined input functions must return bytea while user-defined output 
-	 * functions must return text.
+	/*
+	 * User-defined input functions must return bytea while user-defined
+	 * output functions must return text.
 	 */
 	if (get_func_rettype(procOid) != expectedRetType)
 		ereport(ERROR,
@@ -464,7 +464,7 @@ check_user_defined_func(Oid funcid, Oid typeOid, Oid expectedNamespace, bool typ
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s function must accept one argument of type %s",
-				 funcType, format_type_be(expectedArgType))));
+						funcType, format_type_be(expectedArgType))));
 	}
 
 	prolang = proc->prolang;
@@ -479,31 +479,31 @@ check_user_defined_func(Oid funcid, Oid typeOid, Oid expectedNamespace, bool typ
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s function cannot be defined in C or internal",
-				 funcType)));
+						funcType)));
 
 	if (prorettype != expectedRetType)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s functions must return type %s",
-				 funcType, format_type_be(expectedRetType))));
+						funcType, format_type_be(expectedRetType))));
 
 	if (namespace != expectedNamespace)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s functions must exist in the same namespace as the type",
-				 funcType)));
+						funcType)));
 
 	if (!proisstrict)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s functions must be strict",
-				 funcType)));
+						funcType)));
 
 	if (provolatile != PROVOLATILE_IMMUTABLE)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 				 errmsg("type %s functions must be immutable",
-				 funcType)));
+						funcType)));
 
 	funcArgList[0] = CSTRINGOID;
 	funcNameList = list_make2(makeString(get_namespace_name(expectedNamespace)),

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -398,7 +398,7 @@ find_user_defined_func(List *procname, bool typeInput)
 	 */
 	argList[0] = typeInput ? TEXTOID : BYTEAOID;
 	expectedRetType = typeInput ? BYTEAOID : TEXTOID;
-	funcType = typeInput ? "input" : "output";
+	funcType = typeInput ? TLE_INPUT_FUNC_STR : TLE_OUTPUT_FUNC_STR;
 
 	procOid = LookupFuncName(procname, 1, argList, true);
 
@@ -457,7 +457,7 @@ check_user_defined_func(Oid funcid, Oid typeOid, Oid expectedNamespace, bool typ
 
 	expectedArgType = typeInput ? TEXTOID : BYTEAOID;
 	expectedRetType = typeInput ? BYTEAOID : TEXTOID;
-	funcType = typeInput ? "input" : "output";
+	funcType = typeInput ? TLE_INPUT_FUNC_STR : TLE_OUTPUT_FUNC_STR;
 	if (proc->pronargs != 1 || proc->proargtypes.values[0] != expectedArgType)
 	{
 		ReleaseSysCache(tuple);

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -126,7 +126,7 @@ $$
   SELECT pg_catalog.convert_to(input1, 'UTF8');
 $$ IMMUTABLE STRICT LANGUAGE sql;
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text, text, text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
-ERROR:  type input/output function must accept one argument of type text
+ERROR:  type input function must accept one argument of type text
 DROP FUNCTION public.test_citext_in2;
 -- Invalid: I/O function argument type mistach
 CREATE FUNCTION public.test_citext_in2(input int) RETURNS bytea AS
@@ -134,7 +134,7 @@ $$
   SELECT '00'::bytea;
 $$ IMMUTABLE STRICT LANGUAGE sql;
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(int)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
-ERROR:  type input/output function must accept one argument of type text
+ERROR:  type input function must accept one argument of type text
 DROP FUNCTION public.test_citext_in2;
 -- Invalid: I/O function return type mistach
 CREATE FUNCTION public.test_citext_in2(input text) RETURNS int AS
@@ -142,7 +142,7 @@ $$
   SELECT 1;
 $$ IMMUTABLE STRICT LANGUAGE sql;
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
-ERROR:  type input/output functions must return type bytea
+ERROR:  type input functions must return type bytea
 DROP FUNCTION public.test_citext_in2;
 -- Invalid: I/O function not immutable
 CREATE FUNCTION public.test_citext_in2(input text) RETURNS bytea AS
@@ -150,7 +150,7 @@ $$
   SELECT pg_catalog.convert_to(input, 'UTF8');
 $$ STABLE STRICT LANGUAGE sql;
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
-ERROR:  type input/output functions must be immutable
+ERROR:  type input functions must be immutable
 DROP FUNCTION public.test_citext_in2;
 -- Invalid: I/O function not strict
 CREATE FUNCTION public.test_citext_in2(input text) RETURNS bytea AS
@@ -158,7 +158,7 @@ $$
   SELECT pg_catalog.convert_to(input, 'UTF8');
 $$ IMMUTABLE LANGUAGE sql;
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
-ERROR:  type input/output functions must be strict
+ERROR:  type input functions must be strict
 DROP FUNCTION public.test_citext_in2;
 -- Valid
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -117,6 +117,49 @@ SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::r
 ERROR:  invalid type internal length 0
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, 32767);
 ERROR:  invalid type internal length 32767, maximum size is 32763
+-- Invalid: not owner of I/O function
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'pg_catalog.bttextcmp(text, text)'::regprocedure, -1);
+ERROR:  must be owner of function bttextcmp
+-- Invalid: I/O function argument length mistach
+CREATE FUNCTION public.test_citext_in2(input1 text, input2 text, input3 text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input1, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text, text, text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+ERROR:  type input/output function must accept one argument of type text
+DROP FUNCTION public.test_citext_in2;
+-- Invalid: I/O function argument type mistach
+CREATE FUNCTION public.test_citext_in2(input int) RETURNS bytea AS
+$$
+  SELECT '00'::bytea;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(int)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+ERROR:  type input/output function must accept one argument of type text
+DROP FUNCTION public.test_citext_in2;
+-- Invalid: I/O function return type mistach
+CREATE FUNCTION public.test_citext_in2(input text) RETURNS int AS
+$$
+  SELECT 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+ERROR:  type input/output functions must return type bytea
+DROP FUNCTION public.test_citext_in2;
+-- Invalid: I/O function not immutable
+CREATE FUNCTION public.test_citext_in2(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ STABLE STRICT LANGUAGE sql;
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+ERROR:  type input/output functions must be immutable
+DROP FUNCTION public.test_citext_in2;
+-- Invalid: I/O function not strict
+CREATE FUNCTION public.test_citext_in2(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ IMMUTABLE LANGUAGE sql;
+SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in2(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+ERROR:  type input/output functions must be strict
+DROP FUNCTION public.test_citext_in2;
 -- Valid
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
  create_base_type 


### PR DESCRIPTION
Although this is not strictly required in `CREATE TYPE` command, it's generally preferred. If there's a strong reason to lift the restriction in the future, we can re-consider at that time.
Also, refactored `check_user_defined_func` and `find_user_defined_func ` function a bit to improve readability.


Reference:
https://github.com/postgres/postgres/blob/master/src/backend/commands/typecmds.c#L1987

https://www.postgresql.org/docs/current/sql-createtype.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
