### PR TITLE
Add REL_16_STABLE to CI/CD

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [master, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
PostgreSQL branched for v16, so we need to test this explicit branch for v16 compatibility.

Also note that v16 introduced the meson build system, so at some point we'll need to add support for that vis-a-vis the CI/CD.