### PR TITLE
Disallow REPLACE or ALTER functions used or defined by pg_tle datatype APIs.

### DIFF
--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -362,12 +362,20 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 }
 #endif
 
-#if (PG_VERSION_NUM >= 160000)
+#if PG_VERSION_NUM >= 160000
 #define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
 	CastCreate(sourcetypeid, targettypeid, funcid, InvalidOid, InvalidOid, castcontext, castmethod, behavior)
 #else
 #define CAST_CREATE(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior) \
 	CastCreate(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior)
+#endif
+
+#if PG_VERSION_NUM >= 140000
+#define FUNCNAME_GET_CANDIDATES(names, nargs, argnames, expand_variadic, expand_defaults, missing_ok) \
+	FuncnameGetCandidates(names, nargs, argnames, expand_variadic, expand_defaults, false /* include_out_arguments */, missing_ok)
+#else
+#define FUNCNAME_GET_CANDIDATES(names, nargs, argnames, expand_variadic, expand_defaults, missing_ok) \
+	FuncnameGetCandidates(names, nargs, argnames, expand_variadic, expand_defaults, missing_ok)
 #endif
 
 #if PG_VERSION_NUM >= 140000

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -5101,9 +5101,14 @@ is_pgtle_defined_c_func(Oid funcid, bool *is_operator_func)
 	prosrcstring = TextDatumGetCString(prosrcattr);
 	ReleaseSysCache(tuple);
 
-	return strncmp(prosrcstring, TLE_BASE_TYPE_IN, sizeof(TLE_BASE_TYPE_IN)) == 0 ||
-			strncmp(prosrcstring, TLE_BASE_TYPE_OUT, sizeof(TLE_BASE_TYPE_OUT)) == 0 ||
-			strncmp(prosrcstring, TLE_OPERATOR_FUNC, sizeof(TLE_OPERATOR_FUNC)) == 0;
+	if (strncmp(prosrcstring, TLE_OPERATOR_FUNC, sizeof(TLE_OPERATOR_FUNC)) == 0)
+		*is_operator_func = true;
+	else
+		*is_operator_func = false;
+
+	return *is_operator_func ||
+			strncmp(prosrcstring, TLE_BASE_TYPE_IN, sizeof(TLE_BASE_TYPE_IN)) == 0 ||
+			strncmp(prosrcstring, TLE_BASE_TYPE_OUT, sizeof(TLE_BASE_TYPE_OUT)) == 0;
 }
 
 /*
@@ -5202,7 +5207,7 @@ check_pgtle_used_func(Oid funcid)
 	if (!result)
 		return;
 
-	ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					errmsg("Alter or replace pg_tle used %s function %s is not allowed",
-						   is_operator_func ? "operator" : "type I/O", get_func_name(funcid))));
+	ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("ALTER or REPLACE of pg_tle used datatype %s function %s is not allowed",
+						   is_operator_func ? "operator" : "I/O", get_func_name(funcid))));
 }

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -22,6 +22,10 @@ GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbstaff;
 GRANT USAGE ON SCHEMA PUBLIC TO dbuser1;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser2;
 SET search_path TO pgtle,public;
+CREATE SCHEMA test_schema;
+CREATE ROLE dbuser3;
+GRANT dbuser3 TO pgtle_admin;
+GRANT CREATE, USAGE ON SCHEMA test_schema TO dbuser3;
 -- unprivileged role cannot execute pgtle.create_shell_type and create_shell_type_if_not_exists
 SET SESSION AUTHORIZATION dbstaff;
 SELECT CURRENT_USER;
@@ -167,6 +171,104 @@ SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::r
  
 (1 row)
 
+-- REPLACE type I/O functions
+CREATE OR REPLACE FUNCTION public.test_citext_in(input aaa) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+ERROR:  type aaa does not exist
+CREATE OR REPLACE FUNCTION public.test_citext_in(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+CREATE OR REPLACE FUNCTION public.test_citext_in(input cstring) RETURNS test_citext
+AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
+LANGUAGE C PARALLEL SAFE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+CREATE OR REPLACE FUNCTION public.test_citext_out(input bytea) RETURNS text AS
+$$
+  SELECT pg_catalog.convert_from(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+CREATE OR REPLACE FUNCTION public.test_citext_out(input test_citext) RETURNS cstring
+AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
+LANGUAGE C PARALLEL SAFE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+CREATE OR REPLACE FUNCTION public.test_citext_in(i INT) RETURNS INT AS
+$$
+  SELECT 1;
+$$ STRICT LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION public.test_citext_out(i INT) RETURNS INT AS
+$$
+  SELECT 1;
+$$ STRICT LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION public.test_citext_in(i INT) RETURNS INT AS
+$$
+  SELECT 2;
+$$ STRICT LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION public.test_citext_out(i INT) RETURNS INT AS
+$$
+  SELECT 2;
+$$ STRICT LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION public.another_func(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ STRICT LANGUAGE SQL;
+-- ALTER type I/O functions
+ALTER FUNCTION public.test_citext_in(text) STABLE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_in(cstring) STABLE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_out(bytea) STABLE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_out(test_citext) STABLE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_in(int) STABLE;
+ALTER FUNCTION public.test_citext_out(int) STABLE;
+ALTER FUNCTION public.another_func(text) STABLE;
+-- ALTER type I/O functions OWNER
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbuser3;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_in(cstring) OWNER TO dbuser3;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_out(bytea) OWNER TO dbuser3;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_out(test_citext) OWNER TO dbuser3;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_in(int) OWNER TO dbuser3;
+ERROR:  permission denied for schema public
+ALTER FUNCTION public.test_citext_out(int) OWNER TO dbuser3;
+ERROR:  permission denied for schema public
+ALTER FUNCTION public.another_func(text) OWNER TO dbuser3;
+ERROR:  permission denied for schema public
+-- RENAME type I/O functions
+ALTER FUNCTION public.test_citext_in(text) RENAME TO test_citext_in2;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_in(cstring) RENAME TO test_citext_in2;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_out(bytea) RENAME TO test_citext_in2;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_out(test_citext) RENAME TO test_citext_in2;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_in(int) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_out(int) RENAME TO test_citext_out2;
+ALTER FUNCTION public.another_func(text) RENAME TO another_func2;
+-- ALTER type I/O functions schema
+ALTER FUNCTION public.test_citext_in(text) SET SCHEMA test_schema;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_in(cstring) SET SCHEMA test_schema;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ALTER FUNCTION public.test_citext_out(bytea) SET SCHEMA test_schema;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_out(test_citext) SET SCHEMA test_schema;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ALTER FUNCTION public.test_citext_in2(int) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_out2(int) SET SCHEMA test_schema;
+ALTER FUNCTION public.another_func2(text) SET SCHEMA test_schema;
+DROP FUNCTION test_schema.test_citext_in2;
+DROP FUNCTION test_schema.test_citext_out2;
+DROP FUNCTION test_schema.another_func2;
 CREATE TABLE test_dt(c1 test_citext);
 -- Insert a regular string
 INSERT INTO test_dt VALUES ('TEST');
@@ -323,6 +425,41 @@ SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_g
  
 (1 row)
 
+-- REPLACE type operator functions
+CREATE OR REPLACE FUNCTION public.test_citext_cmp(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+CREATE OR REPLACE FUNCTION public.test_citext_cmp2(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+CREATE OR REPLACE FUNCTION public.test_citext_cmp2(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 2;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+-- ALTER type operator functions
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) STABLE;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) STABLE;
+-- ALTER type operator functions OWNER
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbuser3;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) OWNER TO dbuser3;
+ERROR:  permission denied for schema public
+-- RENAME type operator functions
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) RENAME TO test_citext_in2;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_cmp3;
+-- ALTER type operator functions schema
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
+ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ALTER FUNCTION public.test_citext_cmp3(l bytea, r bytea) SET SCHEMA test_schema;
+DROP FUNCTION test_schema.test_citext_cmp3;
 CREATE OPERATOR < (
     LEFTARG = public.test_citext,
     RIGHTARG = public.test_citext,
@@ -681,10 +818,13 @@ REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbadmin;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbstaff;
 REVOKE USAGE ON SCHEMA PUBLIC FROM dbuser1;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser2;
+REVOKE CREATE, USAGE ON SCHEMA test_schema FROM dbuser3;
+DROP SCHEMA test_schema;
 DROP ROLE dbstaff;
 DROP ROLE dbadmin;
 DROP ROLE dbuser1;
 DROP ROLE dbuser2;
+DROP ROLE dbuser3;
 DROP EXTENSION pg_tle;
 DROP SCHEMA pgtle;
 DROP ROLE pgtle_admin;

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -25,6 +25,7 @@ SET search_path TO pgtle,public;
 CREATE SCHEMA test_schema;
 CREATE ROLE dbuser3;
 GRANT dbuser3 TO pgtle_admin;
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser3;
 GRANT CREATE, USAGE ON SCHEMA test_schema TO dbuser3;
 -- unprivileged role cannot execute pgtle.create_shell_type and create_shell_type_if_not_exists
 SET SESSION AUTHORIZATION dbstaff;
@@ -171,7 +172,7 @@ SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::r
  
 (1 row)
 
--- REPLACE type I/O functions
+-- Invalid: REPLACE type I/O functions
 CREATE OR REPLACE FUNCTION public.test_citext_in(input aaa) RETURNS bytea AS
 $$
   SELECT pg_catalog.convert_to(input, 'UTF8');
@@ -181,20 +182,21 @@ CREATE OR REPLACE FUNCTION public.test_citext_in(input text) RETURNS bytea AS
 $$
   SELECT pg_catalog.convert_to(input, 'UTF8');
 $$ IMMUTABLE STRICT LANGUAGE sql;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 CREATE OR REPLACE FUNCTION public.test_citext_in(input cstring) RETURNS test_citext
 AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
 LANGUAGE C PARALLEL SAFE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 CREATE OR REPLACE FUNCTION public.test_citext_out(input bytea) RETURNS text AS
 $$
   SELECT pg_catalog.convert_from(input, 'UTF8');
 $$ IMMUTABLE STRICT LANGUAGE sql;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
 CREATE OR REPLACE FUNCTION public.test_citext_out(input test_citext) RETURNS cstring
 AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
 LANGUAGE C PARALLEL SAFE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
+-- Valid: CREATE OR REPLACE regular functions (name or arg type differs)
 CREATE OR REPLACE FUNCTION public.test_citext_in(i INT) RETURNS INT AS
 $$
   SELECT 1;
@@ -215,54 +217,55 @@ CREATE OR REPLACE FUNCTION public.another_func(input text) RETURNS bytea AS
 $$
   SELECT pg_catalog.convert_to(input, 'UTF8');
 $$ STRICT LANGUAGE SQL;
--- ALTER type I/O functions
+-- Invalid: ALTER type I/O functions
 ALTER FUNCTION public.test_citext_in(text) STABLE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_in(cstring) STABLE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_out(bytea) STABLE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
 ALTER FUNCTION public.test_citext_out(test_citext) STABLE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
+-- Valid: ALTER regular functions
 ALTER FUNCTION public.test_citext_in(int) STABLE;
 ALTER FUNCTION public.test_citext_out(int) STABLE;
 ALTER FUNCTION public.another_func(text) STABLE;
--- ALTER type I/O functions OWNER
+-- Invalid: ALTER type I/O functions OWNER
 ALTER FUNCTION public.test_citext_in(text) OWNER TO dbuser3;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_in(cstring) OWNER TO dbuser3;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_out(bytea) OWNER TO dbuser3;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
 ALTER FUNCTION public.test_citext_out(test_citext) OWNER TO dbuser3;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
+-- Valid: ALTER regular functions OWNER
 ALTER FUNCTION public.test_citext_in(int) OWNER TO dbuser3;
-ERROR:  permission denied for schema public
 ALTER FUNCTION public.test_citext_out(int) OWNER TO dbuser3;
-ERROR:  permission denied for schema public
 ALTER FUNCTION public.another_func(text) OWNER TO dbuser3;
-ERROR:  permission denied for schema public
--- RENAME type I/O functions
+-- Invalid: RENAME type I/O functions
 ALTER FUNCTION public.test_citext_in(text) RENAME TO test_citext_in2;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_in(cstring) RENAME TO test_citext_in2;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_out(bytea) RENAME TO test_citext_in2;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
 ALTER FUNCTION public.test_citext_out(test_citext) RENAME TO test_citext_in2;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
+-- Valid: RENAME regular functions
 ALTER FUNCTION public.test_citext_in(int) RENAME TO test_citext_in2;
 ALTER FUNCTION public.test_citext_out(int) RENAME TO test_citext_out2;
 ALTER FUNCTION public.another_func(text) RENAME TO another_func2;
--- ALTER type I/O functions schema
+-- Invalid: ALTER type I/O functions schema
 ALTER FUNCTION public.test_citext_in(text) SET SCHEMA test_schema;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_in(cstring) SET SCHEMA test_schema;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_in is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_in is not allowed
 ALTER FUNCTION public.test_citext_out(bytea) SET SCHEMA test_schema;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
 ALTER FUNCTION public.test_citext_out(test_citext) SET SCHEMA test_schema;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_out is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is not allowed
+-- Valid: ALTER regular functions schema
 ALTER FUNCTION public.test_citext_in2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.test_citext_out2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.another_func2(text) SET SCHEMA test_schema;
@@ -356,9 +359,13 @@ SET SESSION AUTHORIZATION dbstaff;
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
 ERROR:  permission denied for function create_operator_func
 -- no CREATE priviliege in the namespace
+RESET SESSION AUTHORIZATION;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser3;
 SET SESSION AUTHORIZATION dbuser1;
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
 ERROR:  permission denied for schema public
+RESET SESSION AUTHORIZATION;
+GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser3;
 -- not owner of the base type
 SET SESSION AUTHORIZATION dbuser2;
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_cmp(bytea, bytea)'::regprocedure);
@@ -425,13 +432,14 @@ SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_g
  
 (1 row)
 
--- REPLACE type operator functions
+-- Invalid: REPLACE pgtle used type operator functions
 CREATE OR REPLACE FUNCTION public.test_citext_cmp(l bytea, r bytea)
 RETURNS int AS
 $$
   SELECT 1;
 $$ IMMUTABLE STRICT LANGUAGE sql;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
+-- Valid: CREATE OR REPLACE regular functions (name or arg type differs)
 CREATE OR REPLACE FUNCTION public.test_citext_cmp2(l bytea, r bytea)
 RETURNS int AS
 $$
@@ -442,22 +450,25 @@ RETURNS int AS
 $$
   SELECT 2;
 $$ IMMUTABLE STRICT LANGUAGE sql;
--- ALTER type operator functions
+-- Invalid: ALTER pgtle used type operator functions
 ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) STABLE;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
+-- Valid: ALTER regular functions
 ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) STABLE;
--- ALTER type operator functions OWNER
+-- Invalid: ALTER pgtle used type operator functions OWNER
 ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbuser3;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
+-- Valid: ALTER regular functions OWNER
 ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) OWNER TO dbuser3;
-ERROR:  permission denied for schema public
--- RENAME type operator functions
+-- Invalid: RENAME pgtle used type operator functions
 ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) RENAME TO test_citext_in2;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
+-- Valid: RENAME regular functions
 ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_cmp3;
--- ALTER type operator functions schema
+-- Invalid: ALTER pgtle used type operator functions schema
 ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
-ERROR:  Alter or replace pg_tle used type I/O function test_citext_cmp is not allowed
+ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
+-- Valid: ALTER regular functions schema
 ALTER FUNCTION public.test_citext_cmp3(l bytea, r bytea) SET SCHEMA test_schema;
 DROP FUNCTION test_schema.test_citext_cmp3;
 CREATE OPERATOR < (
@@ -688,6 +699,20 @@ INSERT INTO test_dt VALUES ('SELECT'), ('INSERT'), ('UPDATE'), ('DELETE');
 INSERT INTO test_dt VALUES ('select');
 ERROR:  duplicate key value violates unique constraint "test_dt_pkey"
 DETAIL:  Key (c1)=(select) already exists.
+-- Valid: ALTER or REPLACE operator functions not used by pgtle API
+CREATE OR REPLACE FUNCTION public.test_citext_cmp(l test_citext, r test_citext) 
+RETURNS int AS
+$$
+BEGIN
+  RETURN public.test_citext_cmp(l::bytea, r::bytea);
+END;
+$$ IMMUTABLE STRICT LANGUAGE plpgsql;
+ALTER FUNCTION public.test_citext_cmp(l test_citext, r test_citext) STABLE;
+ALTER FUNCTION public.test_citext_cmp(l test_citext, r test_citext) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_cmp(l test_citext, r test_citext) RENAME TO test_citext_cmp2;
+ALTER FUNCTION public.test_citext_cmp2(l test_citext, r test_citext) RENAME TO test_citext_cmp;
+ALTER FUNCTION public.test_citext_cmp(l test_citext, r test_citext) SET SCHEMA test_schema;
+ALTER FUNCTION test_schema.test_citext_cmp(l test_citext, r test_citext) SET SCHEMA PUBLIC;
 -- Drop user-defined operator functions
 DROP FUNCTION test_citext_cmp(bytea, bytea) CASCADE;
 DROP FUNCTION test_citext_eq(bytea, bytea) CASCADE;
@@ -818,6 +843,7 @@ REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbadmin;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbstaff;
 REVOKE USAGE ON SCHEMA PUBLIC FROM dbuser1;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser2;
+REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser3;
 REVOKE CREATE, USAGE ON SCHEMA test_schema FROM dbuser3;
 DROP SCHEMA test_schema;
 DROP ROLE dbstaff;

--- a/test/sql/pg_tle_datatype.sql
+++ b/test/sql/pg_tle_datatype.sql
@@ -28,6 +28,11 @@ GRANT USAGE ON SCHEMA PUBLIC TO dbuser1;
 GRANT CREATE, USAGE ON SCHEMA PUBLIC TO dbuser2;
 SET search_path TO pgtle,public;
 
+CREATE SCHEMA test_schema;
+CREATE ROLE dbuser3;
+GRANT dbuser3 TO pgtle_admin;
+GRANT CREATE, USAGE ON SCHEMA test_schema TO dbuser3;
+
 -- unprivileged role cannot execute pgtle.create_shell_type and create_shell_type_if_not_exists
 SET SESSION AUTHORIZATION dbstaff;
 SELECT CURRENT_USER;
@@ -122,6 +127,96 @@ DROP FUNCTION public.test_citext_in2;
 
 -- Valid
 SELECT pgtle.create_base_type('public', 'test_citext', 'test_citext_in(text)'::regprocedure, 'test_citext_out(bytea)'::regprocedure, -1);
+
+
+-- REPLACE type I/O functions
+CREATE OR REPLACE FUNCTION public.test_citext_in(input aaa) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION public.test_citext_in(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION public.test_citext_in(input cstring) RETURNS test_citext
+AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
+LANGUAGE C PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION public.test_citext_out(input bytea) RETURNS text AS
+$$
+  SELECT pg_catalog.convert_from(input, 'UTF8');
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION public.test_citext_out(input test_citext) RETURNS cstring
+AS 'MODULE_PATHNAME', 'pg_tle_create_shell_type'
+LANGUAGE C PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION public.test_citext_in(i INT) RETURNS INT AS
+$$
+  SELECT 1;
+$$ STRICT LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION public.test_citext_out(i INT) RETURNS INT AS
+$$
+  SELECT 1;
+$$ STRICT LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION public.test_citext_in(i INT) RETURNS INT AS
+$$
+  SELECT 2;
+$$ STRICT LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION public.test_citext_out(i INT) RETURNS INT AS
+$$
+  SELECT 2;
+$$ STRICT LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION public.another_func(input text) RETURNS bytea AS
+$$
+  SELECT pg_catalog.convert_to(input, 'UTF8');
+$$ STRICT LANGUAGE SQL;
+
+-- ALTER type I/O functions
+ALTER FUNCTION public.test_citext_in(text) STABLE;
+ALTER FUNCTION public.test_citext_in(cstring) STABLE;
+ALTER FUNCTION public.test_citext_out(bytea) STABLE;
+ALTER FUNCTION public.test_citext_out(test_citext) STABLE;
+ALTER FUNCTION public.test_citext_in(int) STABLE;
+ALTER FUNCTION public.test_citext_out(int) STABLE;
+ALTER FUNCTION public.another_func(text) STABLE;
+
+-- ALTER type I/O functions OWNER
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_in(cstring) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_out(bytea) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_out(test_citext) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_in(int) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_out(int) OWNER TO dbuser3;
+ALTER FUNCTION public.another_func(text) OWNER TO dbuser3;
+
+-- RENAME type I/O functions
+ALTER FUNCTION public.test_citext_in(text) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_in(cstring) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_out(bytea) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_out(test_citext) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_in(int) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_out(int) RENAME TO test_citext_out2;
+ALTER FUNCTION public.another_func(text) RENAME TO another_func2;
+
+-- ALTER type I/O functions schema
+ALTER FUNCTION public.test_citext_in(text) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_in(cstring) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_out(bytea) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_out(test_citext) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_in2(int) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_out2(int) SET SCHEMA test_schema;
+ALTER FUNCTION public.another_func2(text) SET SCHEMA test_schema;
+
+DROP FUNCTION test_schema.test_citext_in2;
+DROP FUNCTION test_schema.test_citext_out2;
+DROP FUNCTION test_schema.another_func2;
 
 CREATE TABLE test_dt(c1 test_citext);
 -- Insert a regular string
@@ -225,6 +320,43 @@ SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_e
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_ne(bytea, bytea)'::regprocedure);
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_gt(bytea, bytea)'::regprocedure);
 SELECT pgtle.create_operator_func('public', 'test_citext', 'public.test_citext_ge(bytea, bytea)'::regprocedure);
+
+-- REPLACE type operator functions
+CREATE OR REPLACE FUNCTION public.test_citext_cmp(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION public.test_citext_cmp2(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 1;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION public.test_citext_cmp2(l bytea, r bytea)
+RETURNS int AS
+$$
+  SELECT 2;
+$$ IMMUTABLE STRICT LANGUAGE sql;
+
+-- ALTER type operator functions
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) STABLE;
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) STABLE;
+
+-- ALTER type operator functions OWNER
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) OWNER TO dbuser3;
+
+-- RENAME type operator functions
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_cmp3;
+
+-- ALTER type operator functions schema
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
+ALTER FUNCTION public.test_citext_cmp3(l bytea, r bytea) SET SCHEMA test_schema;
+
+DROP FUNCTION test_schema.test_citext_cmp3;
 
 CREATE OPERATOR < (
     LEFTARG = public.test_citext,
@@ -530,10 +662,13 @@ REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbadmin;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbstaff;
 REVOKE USAGE ON SCHEMA PUBLIC FROM dbuser1;
 REVOKE CREATE, USAGE ON SCHEMA PUBLIC FROM dbuser2;
+REVOKE CREATE, USAGE ON SCHEMA test_schema FROM dbuser3;
+DROP SCHEMA test_schema;
 DROP ROLE dbstaff;
 DROP ROLE dbadmin;
 DROP ROLE dbuser1;
 DROP ROLE dbuser2;
+DROP ROLE dbuser3;
 DROP EXTENSION pg_tle;
 DROP SCHEMA pgtle;
 DROP ROLE pgtle_admin;


### PR DESCRIPTION
If a user-defined function is used by pgtle datatype API (i.e. `create_base_type` or `create_operator_func`), we will define a C-version function with the same name (different argument types).

Replacing or altering these functions can be error-prone. For example, if a user defined function is renamed, we won't be able to find it in the C version function because we rely on the same name as a mapping.

One note is that for operator functions, it will only be restricted if it's created or used by `create_operator_func` API.

Dropping these functions is still allowed, and will drop the dependent objects cascade.

Blocked commands:
1. `CREATE OR REPLACE FUNCTION xxx`;
2. `ALTER FUNCTION xxx`;
3. `ALTER FUNCTION xxx RENAME TO xxx`;
4. `ALTER FUNCTION xxx SET SCHEMA xxx`;
5. `ALTER FUNCTION xxx OWNER TO xxx`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
