### PR TITLE
Allow superuser to replace/alter pg_tle used type functions.

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4153,7 +4153,7 @@ _PU_HOOK
 			}
 
 			/* CREATE OR REPLACE FUNCTION */
-			if (n->replace && !n->is_procedure)
+			if (!superuser() && n->replace && !n->is_procedure)
 			{
 				int			nargs;
 				List	   *funcNameList;
@@ -4235,8 +4235,11 @@ _PU_HOOK
 				}
 			}
 
-			funcid = LookupFuncWithArgs(n->objtype, n->func, true);
-			check_pgtle_used_func(funcid);
+			if (!superuser())
+			{
+				funcid = LookupFuncWithArgs(n->objtype, n->func, true);
+				check_pgtle_used_func(funcid);
+			}
 
 			break;
 		}
@@ -4279,7 +4282,7 @@ _PU_HOOK
 				}
 			}
 
-			if (n->objectType == OBJECT_FUNCTION)
+			if (!superuser() && n->objectType == OBJECT_FUNCTION)
 			{
 				ObjectAddress address;
 				Relation	relation;
@@ -4298,7 +4301,7 @@ _PU_HOOK
 		{
 			RenameStmt *stmt = (RenameStmt *) pu_parsetree;
 
-			if (stmt->renameType == OBJECT_FUNCTION)
+			if (!superuser() && stmt->renameType == OBJECT_FUNCTION)
 			{
 				ObjectAddress address;
 				Relation	relation;
@@ -4316,7 +4319,7 @@ _PU_HOOK
 		{
 			AlterOwnerStmt *stmt = (AlterOwnerStmt *) pu_parsetree;
 
-			if (stmt->objectType == OBJECT_FUNCTION)
+			if (!superuser() && stmt->objectType == OBJECT_FUNCTION)
 			{
 				ObjectAddress address;
 				Relation	relation;

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -269,6 +269,16 @@ ERROR:  ALTER or REPLACE of pg_tle used datatype I/O function test_citext_out is
 ALTER FUNCTION public.test_citext_in2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.test_citext_out2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.another_func2(text) SET SCHEMA test_schema;
+-- Superuser can alter type I/O functions
+RESET SESSION AUTHORIZATION;
+ALTER FUNCTION public.test_citext_in(text) IMMUTABLE;
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbadmin;
+ALTER FUNCTION public.test_citext_in(text) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_in2(text) RENAME TO test_citext_in;
+ALTER FUNCTION public.test_citext_in(text) SET SCHEMA test_schema;
+ALTER FUNCTION test_schema.test_citext_in(text) SET SCHEMA public;
+SET SESSION AUTHORIZATION dbadmin;
 DROP FUNCTION test_schema.test_citext_in2;
 DROP FUNCTION test_schema.test_citext_out2;
 DROP FUNCTION test_schema.another_func2;
@@ -470,6 +480,17 @@ ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
 ERROR:  ALTER or REPLACE of pg_tle used datatype operator function test_citext_cmp is not allowed
 -- Valid: ALTER regular functions schema
 ALTER FUNCTION public.test_citext_cmp3(l bytea, r bytea) SET SCHEMA test_schema;
+-- Superuser can alter pgtle used type operator functions
+RESET SESSION AUTHORIZATION;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) STABLE;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) IMMUTABLE;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbadmin;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) RENAME TO test_citext_cmp2;
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_cmp;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
+ALTER FUNCTION test_schema.test_citext_cmp(l bytea, r bytea) SET SCHEMA public;
+SET SESSION AUTHORIZATION dbadmin;
 DROP FUNCTION test_schema.test_citext_cmp3;
 CREATE OPERATOR < (
     LEFTARG = public.test_citext,

--- a/test/sql/pg_tle_datatype.sql
+++ b/test/sql/pg_tle_datatype.sql
@@ -219,6 +219,17 @@ ALTER FUNCTION public.test_citext_in2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.test_citext_out2(int) SET SCHEMA test_schema;
 ALTER FUNCTION public.another_func2(text) SET SCHEMA test_schema;
 
+-- Superuser can alter type I/O functions
+RESET SESSION AUTHORIZATION;
+ALTER FUNCTION public.test_citext_in(text) IMMUTABLE;
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_in(text) OWNER TO dbadmin;
+ALTER FUNCTION public.test_citext_in(text) RENAME TO test_citext_in2;
+ALTER FUNCTION public.test_citext_in2(text) RENAME TO test_citext_in;
+ALTER FUNCTION public.test_citext_in(text) SET SCHEMA test_schema;
+ALTER FUNCTION test_schema.test_citext_in(text) SET SCHEMA public;
+SET SESSION AUTHORIZATION dbadmin;
+
 DROP FUNCTION test_schema.test_citext_in2;
 DROP FUNCTION test_schema.test_citext_out2;
 DROP FUNCTION test_schema.another_func2;
@@ -369,6 +380,18 @@ ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_c
 ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
 -- Valid: ALTER regular functions schema
 ALTER FUNCTION public.test_citext_cmp3(l bytea, r bytea) SET SCHEMA test_schema;
+
+-- Superuser can alter pgtle used type operator functions
+RESET SESSION AUTHORIZATION;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) STABLE;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) IMMUTABLE;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbuser3;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) OWNER TO dbadmin;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) RENAME TO test_citext_cmp2;
+ALTER FUNCTION public.test_citext_cmp2(l bytea, r bytea) RENAME TO test_citext_cmp;
+ALTER FUNCTION public.test_citext_cmp(l bytea, r bytea) SET SCHEMA test_schema;
+ALTER FUNCTION test_schema.test_citext_cmp(l bytea, r bytea) SET SCHEMA public;
+SET SESSION AUTHORIZATION dbadmin;
 
 DROP FUNCTION test_schema.test_citext_cmp3;
 


### PR DESCRIPTION
Allow superuser to replace/alter pg_tle used type functions.
During pg_upgrade, superuser may need to replace/alter these functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
