### PR TITLE
Allow `ALTER FUNCTION OWNER` during upgrade.

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4316,7 +4316,7 @@ _PU_HOOK
 		{
 			AlterOwnerStmt *stmt = (AlterOwnerStmt *) pu_parsetree;
 
-			if (stmt->objectType == OBJECT_FUNCTION)
+			if (!IsBinaryUpgrade && stmt->objectType == OBJECT_FUNCTION)
 			{
 				ObjectAddress address;
 				Relation	relation;


### PR DESCRIPTION
`ALTER FUNCTION OWNER` is executed on pg_tle type functions during pg_upgrade; without this change, pg_upgrade with pg_tle type would fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
