### PR TITLE
Add missing dependencies on control/SQL functions when TLE is created via cascade

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1887,8 +1887,8 @@ CreateExtensionInternal(char *extensionName,
 	List	   *evi_list;
 	ExtensionVersionInfo *evi_start;
 	ExtensionVersionInfo *evi_target;
-	ObjectAddress ctlfunc,
-				sqlfunc;
+	ObjectAddress ctlfunc;
+	ObjectAddress sqlfunc;
 
 	/*
 	 * We have to do some state checking here if we are cascading through a

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2113,7 +2113,10 @@ CreateExtensionInternal(char *extensionName,
 
 	if (tleext)
 	{
-		/* Record dependency on .control and .sql functions */
+		/*
+		 * Record dependencies on .control and .sql functions so that they are
+		 * dumped/restored before the TLE
+		 */
 		ctlname = psprintf("%s.control", extensionName);
 		ctlfuncid = get_tlefunc_oid_if_exists(ctlname);
 		if (ctlfuncid == InvalidOid)
@@ -2121,17 +2124,14 @@ CreateExtensionInternal(char *extensionName,
 
 		sqlname = psprintf("%s--%s.sql", extensionName, versionName);
 		sqlfuncid = get_tlefunc_oid_if_exists(sqlname);
-		elog(LOG, "extensionName: %s, versionName: %s, sqlfuncid: %d", extensionName, versionName, sqlfuncid);
 
-		/*
-		 * Record dependencies on control function and sql function for base
-		 * version
-		 */
+		/* Record dependencies on control function */
 		ctlfunc.classId = ProcedureRelationId;
 		ctlfunc.objectId = ctlfuncid;
 		ctlfunc.objectSubId = 0;
 		recordDependencyOn(&address, &ctlfunc, DEPENDENCY_NORMAL);
 
+		/* If it exists, record dependencies on sql function for base version */
 		if (sqlfuncid != InvalidOid)
 		{
 			sqlfunc.classId = ProcedureRelationId;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2113,10 +2113,7 @@ CreateExtensionInternal(char *extensionName,
 
 	if (tleext)
 	{
-		/*
-		 * Record dependencies on .control and .sql functions so that they are
-		 * dumped/restored before the TLE
-		 */
+		/* Record dependencies on .control and .sql functions */
 		ctlname = psprintf("%s.control", extensionName);
 		ctlfuncid = get_tlefunc_oid_if_exists(ctlname);
 		if (ctlfuncid == InvalidOid)

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -16,7 +16,7 @@
 #
 # 1. Install and create a regular TLE
 # 2. Install and create a TLE with an indirect version upgrade path
-# 3. Install and create a TLE that depends on another TLE
+# 3. Install and create a TLE that depends on another TLE with an indirect version
 # 4. Create a custom data type
 # 5. Create a custom operator
 

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -16,8 +16,9 @@
 #
 # 1. Install and create a regular TLE
 # 2. Install and create a TLE with an indirect version upgrade path
-# 3. Create a custom data type
-# 4. Create a custom operator
+# 3. Install and create a TLE that depends on another TLE
+# 4. Create a custom data type
+# 5. Create a custom operator
 
 use strict;
 use warnings;
@@ -115,7 +116,54 @@ like  ($stderr, qr//, 'create_tle_2');
 $node->psql($testdb, 'SELECT bar()', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/1/, 'select_tle_function_2');
 
-# 3. Create a custom data type
+# 3. Install and create a TLE that depends on another TLE
+
+$node->psql(
+    $testdb, qq[
+    SELECT pgtle.install_extension
+    (
+      'test_cascade_dependency',
+      '1.0',
+      'Test TLE Functions',
+    \$_pgtle_\$
+      CREATE OR REPLACE FUNCTION test_cascade_dependency_func()
+      RETURNS INT AS \$\$
+      (
+        SELECT 0
+      )\$\$ LANGUAGE sql;
+    \$_pgtle_\$
+    );
+    ], stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'install_tle');
+
+$node->psql(
+    $testdb, qq[
+    SELECT pgtle.install_extension
+    (
+      'test_cascade',
+      '1.0',
+      'Test TLE Functions',
+    \$_pgtle_\$
+      CREATE OR REPLACE FUNCTION test_cascade_func()
+      RETURNS INT AS \$\$
+      (
+        SELECT 1
+      )\$\$ LANGUAGE sql;
+    \$_pgtle_\$,
+      array['test_cascade_dependency']
+    );
+    ], stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'install_tle');
+
+$node->psql($testdb, "CREATE EXTENSION test_cascade CASCADE", stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'create_tle');
+
+$node->psql($testdb, 'SELECT test_cascade_func()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/1/, 'select_tle_function');
+$node->psql($testdb, 'SELECT test_cascade_dependency_func()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/0/, 'select_tle_function');
+
+# 4. Create a custom data type
 
 $node->psql($testdb, 'SELECT pgtle.create_shell_type(\'public\', \'test_citext\')', stdout => \$stdout, stderr => \$stderr);
 like  ($stderr, qr//, 'create_shell_type');
@@ -146,7 +194,7 @@ like  ($stderr, qr//, 'insert_custom_data_type');
 $node->psql($testdb, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/TEST/, 'select_custom_data_type');
 
-# 4. Create a custom data operator
+# 5. Create a custom data operator
 
 $node->psql($testdb, qq[CREATE FUNCTION public.test_citext_cmp(l bytea, r bytea) RETURNS int AS
     \$\$
@@ -219,12 +267,19 @@ like  ($stdout, qr/42/, 'select_tle_function_from_restored_db');
 $node->psql($restored_db, 'SELECT bar()', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/1/, 'select_tle_function_from_restored_db_2');
 
-# 3. Verify custom data type
+# 3. Verify TLE with dependency
+
+$node->psql($restored_db, 'SELECT test_cascade_func()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/1/, 'select_tle_function_from_restored_db_3');
+$node->psql($restored_db, 'SELECT test_cascade_dependency_func()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/0/, 'select_tle_function_from_restored_db_3');
+
+# 4. Verify custom data type
 
 $node->psql($restored_db, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/TEST/, 'select_custom_data_type_from_restored_db');
 
-# 4. Verify custom data operator
+# 5. Verify custom data operator
 
 $node->psql($restored_db, 'SELECT (c1 = c1) as c2 from test_dt', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/t/, 'operator_from_restored_db');


### PR DESCRIPTION
Issue #, if available: #228

Description of changes:

Add dependencies on control and sql functions when an extension is created via cascade. Previously these dependencies were recorded only for the top-level extension. This PR moves this logic to CreateExtensionInternal where it is run for each cascading TLE.

Running the scenario reported in #228:

```
postgres=# create extension pg_tle;
CREATE EXTENSION
postgres=# select pgtle.install_extension(
postgres(#     'ofoo',
postgres(#     '1',
postgres(#     'ofoo',
postgres(#     'create function ofoo_exists() returns int language sql as $$select 1$$'
postgres(# );
 install_extension
-------------------
 t
(1 row)

postgres=# select pgtle.install_extension(
postgres(#     'obar',
postgres(#     '1',
postgres(#     'obar',
postgres(#     'create function obar_exists() returns int language sql as $$select 1$$',
postgres(#     array['ofoo']
postgres(# );
 install_extension
-------------------
 t
(1 row)

postgres=# create extension obar cascade;
NOTICE:  installing required extension "ofoo"
CREATE EXTENSION
postgres=# select * from pg_extension;
  oid  | extname | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition
-------+---------+----------+--------------+----------------+------------+-----------+--------------
 14331 | plpgsql |       10 |           11 | f              | 1.0        |           |
 16385 | pg_tle  |       10 |        16384 | f              | 1.2.0      | {16417}   | {""}
 16440 | ofoo    |       10 |         2200 | f              | 1          |           |
 16442 | obar    |       10 |         2200 | f              | 1          |           |
(4 rows)

postgres=# select * from pg_depend where objid = 16440;
 classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype
---------+-------+----------+------------+----------+-------------+---------
    3079 | 16440 |        0 |       3079 |    16385 |           0 | n
    3079 | 16440 |        0 |       2615 |     2200 |           0 | n
    3079 | 16440 |        0 |       1255 |    16437 |           0 | n
    3079 | 16440 |        0 |       1255 |    16436 |           0 | n
(4 rows)

postgres=# select 16437::regproc, 16436::regproc;
       regproc        |       regproc
----------------------+---------------------
 pgtle."ofoo.control" | pgtle."ofoo--1.sql"
(1 row)
```
`ofoo` (which is created through cascading from `obar`) has dependencies recorded correctly on its control and sql functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
