### PR TITLE
Fix validuntil time in passcheck

### DIFF
--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -161,7 +161,7 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 			}
 			else
 			{
-				hookargs[3] = TimestampTzGetDatum(validuntil_time);
+				hookargs[3] = validuntil_time;
 				hookargs[4] = BoolGetDatum(false);
 			}
 

--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -161,7 +161,7 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 			}
 			else
 			{
-				hookargs[3] = DirectFunctionCall1(timestamptz_out, validuntil_time);
+				hookargs[3] = TimestampTzGetDatum(validuntil_time);
 				hookargs[4] = BoolGetDatum(false);
 			}
 

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -51,16 +51,31 @@ SELECT pg_reload_conf();
 ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require, however no entries exist in "pgtle.feature_info" with the feature "passcheck"
 -- Test validuntil_null and validuntil_time
-CREATE OR REPLACE FUNCTION test_validuntil(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz, validuntil_null boolean) RETURNS void AS
+ALTER SYSTEM SET pgtle.enable_password_check = 'on';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+CREATE OR REPLACE FUNCTION test_validuntil(
+    username text,
+    shadow_pass text,
+    password_types pgtle.password_types,
+    validuntil_time TimestampTz,
+    validuntil_null boolean
+) RETURNS void AS
 $$
 BEGIN
-  if validuntil_null then
+  IF validuntil_null THEN
     RAISE EXCEPTION 'Password needs a VALID UNTIL time';
-  end if;
-  RAISE EXCEPTION 'VALID UNTIL time: %', to_char(validuntil_time, 'YYYY-MM-DD');
+  END IF;
+  RAISE NOTICE 'VALID UNTIL time: %', to_char(validuntil_time, 'YYYY-MM-DD');
 END;
 $$
 LANGUAGE PLPGSQL;
+-- Positive case before registering the feature
+ALTER ROLE testuser with password 'pass';
 SELECT pgtle.register_feature('test_validuntil', 'passcheck');
  register_feature 
 ------------------
@@ -74,11 +89,15 @@ CONTEXT:  PL/pgSQL function test_validuntil(text,text,pgtle.password_types,times
 SQL statement "SELECT public.test_validuntil($1::pg_catalog.text, $2::pg_catalog.text, $3::pgtle.password_types, $4::pg_catalog.timestamptz, $5::pg_catalog.bool)"
 -- Expect failure with the given valid until time in the error message
 ALTER ROLE testuser with password 'pass' VALID UNTIL '2023-01-01';
-ERROR:  VALID UNTIL time: 2023-01-01
-CONTEXT:  PL/pgSQL function test_validuntil(text,text,pgtle.password_types,timestamp with time zone,boolean) line 6 at RAISE
-SQL statement "SELECT public.test_validuntil($1::pg_catalog.text, $2::pg_catalog.text, $3::pgtle.password_types, $4::pg_catalog.timestamptz, $5::pg_catalog.bool)"
+NOTICE:  VALID UNTIL time: 2023-01-01
 -- Insert a value into the feature table
-CREATE OR REPLACE FUNCTION password_check_length_greater_than_8(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz,validuntil_null boolean) RETURNS void AS
+CREATE OR REPLACE FUNCTION password_check_length_greater_than_8(
+    username text,
+    shadow_pass text,
+    password_types pgtle.password_types,
+    validuntil_time TimestampTz,
+    validuntil_null boolean
+) RETURNS void AS
 $$
 BEGIN
 if length(shadow_pass) < 8 then

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -50,6 +50,33 @@ SELECT pg_reload_conf();
 -- Expect an error for require if no entries are present
 ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require, however no entries exist in "pgtle.feature_info" with the feature "passcheck"
+-- Test validuntil_null and validuntil_time
+CREATE OR REPLACE FUNCTION test_validuntil(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz, validuntil_null boolean) RETURNS void AS
+$$
+BEGIN
+  if validuntil_null then
+    RAISE EXCEPTION 'Password needs a VALID UNTIL time';
+  end if;
+  RAISE EXCEPTION 'VALID UNTIL time: %', to_char(validuntil_time, 'YYYY-MM-DD');
+END;
+$$
+LANGUAGE PLPGSQL;
+SELECT pgtle.register_feature('test_validuntil', 'passcheck');
+ register_feature 
+------------------
+ 
+(1 row)
+
+-- Expect failure since no VALID UNTIL time is given
+ALTER ROLE testuser with password 'pass';
+ERROR:  Password needs a VALID UNTIL time
+CONTEXT:  PL/pgSQL function test_validuntil(text,text,pgtle.password_types,timestamp with time zone,boolean) line 4 at RAISE
+SQL statement "SELECT public.test_validuntil($1::pg_catalog.text, $2::pg_catalog.text, $3::pgtle.password_types, $4::pg_catalog.timestamptz, $5::pg_catalog.bool)"
+-- Expect failure with the given valid until time in the error message
+ALTER ROLE testuser with password 'pass' VALID UNTIL '2023-01-01';
+ERROR:  VALID UNTIL time: 2023-01-01
+CONTEXT:  PL/pgSQL function test_validuntil(text,text,pgtle.password_types,timestamp with time zone,boolean) line 6 at RAISE
+SQL statement "SELECT public.test_validuntil($1::pg_catalog.text, $2::pg_catalog.text, $3::pgtle.password_types, $4::pg_catalog.timestamptz, $5::pg_catalog.bool)"
 -- Insert a value into the feature table
 CREATE OR REPLACE FUNCTION password_check_length_greater_than_8(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz,validuntil_null boolean) RETURNS void AS
 $$
@@ -63,6 +90,12 @@ LANGUAGE PLPGSQL;
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'passcheck');
  register_feature 
 ------------------
+ 
+(1 row)
+
+SELECT pgtle.unregister_feature('test_validuntil', 'passcheck');
+ unregister_feature 
+--------------------
  
 (1 row)
 
@@ -192,6 +225,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+DROP FUNCTION test_validuntil;
 DROP FUNCTION password_check_length_greater_than_8;
 DROP FUNCTION password_check_only_nums;
 -- OK, one more test. we're going to put a passcheck function in its own schema

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -35,6 +35,24 @@ SELECT pg_reload_conf();
 \c -
 -- Expect an error for require if no entries are present
 ALTER ROLE testuser with password 'pass';
+
+-- Test validuntil_null and validuntil_time
+CREATE OR REPLACE FUNCTION test_validuntil(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz, validuntil_null boolean) RETURNS void AS
+$$
+BEGIN
+  if validuntil_null then
+    RAISE EXCEPTION 'Password needs a VALID UNTIL time';
+  end if;
+  RAISE EXCEPTION 'VALID UNTIL time: %', to_char(validuntil_time, 'YYYY-MM-DD');
+END;
+$$
+LANGUAGE PLPGSQL;
+SELECT pgtle.register_feature('test_validuntil', 'passcheck');
+-- Expect failure since no VALID UNTIL time is given
+ALTER ROLE testuser with password 'pass';
+-- Expect failure with the given valid until time in the error message
+ALTER ROLE testuser with password 'pass' VALID UNTIL '2023-01-01';
+
 -- Insert a value into the feature table
 CREATE OR REPLACE FUNCTION password_check_length_greater_than_8(username text, shadow_pass text, password_types pgtle.password_types, validuntil_time TimestampTz,validuntil_null boolean) RETURNS void AS
 $$
@@ -47,6 +65,7 @@ $$
 LANGUAGE PLPGSQL;
 
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'passcheck');
+SELECT pgtle.unregister_feature('test_validuntil', 'passcheck');
 -- Expect failure since pass is shorter than 8
 ALTER ROLE testuser with password 'pass';
 ALTER ROLE testuser with password 'passwords';
@@ -112,6 +131,7 @@ DROP SCHEMA testuser_2;
 DROP ROLE testuser_2;
 ALTER SYSTEM RESET pgtle.enable_password_check;
 SELECT pg_reload_conf();
+DROP FUNCTION test_validuntil;
 DROP FUNCTION password_check_length_greater_than_8;
 DROP FUNCTION password_check_only_nums;
 -- OK, one more test. we're going to put a passcheck function in its own schema


### PR DESCRIPTION
Issue #, if available: #230

Description of changes: Use TimestampTzGetDatum to convert the validuntil_time to a Datum with the correct value.

This fix was originally in #232 but I am splitting it into its own PR so that it doesn't get held up by the other changes in that PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.