### PR TITLE
Fix flaky test failure from pg_reload_conf timing

### DIFF
--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -64,6 +64,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 CREATE OR REPLACE FUNCTION test_validuntil(
     username text,
     shadow_pass text,

--- a/test/expected/pg_tle_api_clusterwide.out
+++ b/test/expected/pg_tle_api_clusterwide.out
@@ -75,6 +75,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 CREATE OR REPLACE FUNCTION test_validuntil(
     username text,
     shadow_pass text,

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -44,6 +44,8 @@ ALTER ROLE testuser with password 'pass';
 -- Test validuntil_null and validuntil_time
 ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 CREATE OR REPLACE FUNCTION test_validuntil(
     username text,
     shadow_pass text,

--- a/test/sql/pg_tle_api_clusterwide.sql
+++ b/test/sql/pg_tle_api_clusterwide.sql
@@ -51,6 +51,8 @@ ALTER ROLE testuser with password 'pass';
 -- Test validuntil_null and validuntil_time
 ALTER SYSTEM SET pgtle.enable_password_check = 'on';
 SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -
 CREATE OR REPLACE FUNCTION test_validuntil(
     username text,
     shadow_pass text,


### PR DESCRIPTION
Description of changes: New validuntil test in pg_tle_api.sql is failing occasionally due to timing issue after pg_reload_conf. Reconnect to database using \c after each pg_reload_conf to ensure parameters are updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.