### PR TITLE
Allow `@` character in extension names

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -486,8 +486,8 @@ check_valid_extension_name(const char *extensionname)
 	 * Check for alphanumeric character in extension name for now. Although
 	 * this does prevent some naming schemes, it's a more straight forward
 	 * prevention for preventing certain injection attacks due to the way the
-	 * way we rely on functions currently. Allow the '_' or '-' character to
-	 * provide a nice separator if desired.
+	 * way we rely on functions currently. Allow the '_', '-', or '@'
+	 * character to provide a nice separator if desired.
 	 */
 
 	while (extensionname[idx] != '\0')

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 
 #include "access/genam.h"
+#include "utils/fmgrprotos.h"
 #if PG_VERSION_NUM < 120000
 #include "access/heapam.h"
 #endif
@@ -492,7 +493,10 @@ check_valid_extension_name(const char *extensionname)
 
 	while (extensionname[idx] != '\0')
 	{
-		if (!isalnum(extensionname[idx]) && extensionname[idx] != '_' && extensionname[idx] != '-')
+		if (!isalnum(extensionname[idx]) &&
+			extensionname[idx] != '_' &&
+			extensionname[idx] != '-' &&
+			extensionname[idx] != '@')
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("invalid extension name: \"%s\"", extensionname),

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -30,7 +30,6 @@
 #include <unistd.h>
 
 #include "access/genam.h"
-#include "utils/fmgrprotos.h"
 #if PG_VERSION_NUM < 120000
 #include "access/heapam.h"
 #endif

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -815,6 +815,51 @@ SELECT pgtle.available_extension_versions();
 ------------------------------
 (0 rows)
 
+-- install extension with '@' symbol in name
+SELECT pgtle.install_extension
+(
+ 'foo@bar',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION at_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.available_extensions();
+        available_extensions        
+------------------------------------
+ (foo@bar,1.0,"Test TLE Functions")
+(1 row)
+
+CREATE EXTENSION "foo@bar";
+SELECT extname, extversion from pg_extension where extname='foo@bar';
+ extname | extversion 
+---------+------------
+ foo@bar | 1.0
+(1 row)
+
+SELECT at_func();
+ at_func 
+---------
+      42
+(1 row)
+
+DROP EXTENSION "foo@bar";
+SELECT pgtle.uninstall_extension('foo@bar');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
 -- Skip TransactionStmts
 BEGIN;
 SELECT pgtle.available_extension_versions();

--- a/test/sql/pg_tle_management.sql
+++ b/test/sql/pg_tle_management.sql
@@ -531,6 +531,28 @@ SELECT pgtle.uninstall_extension('test42');
 
 SELECT pgtle.available_extension_versions();
 
+-- install extension with '@' symbol in name
+SELECT pgtle.install_extension
+(
+ 'foo@bar',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION at_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+
+SELECT pgtle.available_extensions();
+CREATE EXTENSION "foo@bar";
+SELECT extname, extversion from pg_extension where extname='foo@bar';
+SELECT at_func();
+DROP EXTENSION "foo@bar";
+SELECT pgtle.uninstall_extension('foo@bar');
+
 -- Skip TransactionStmts
 BEGIN;
 SELECT pgtle.available_extension_versions();


### PR DESCRIPTION
Issue #, if available: #241

Description of changes: Add `@` to the extension name character whitelist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
