### PR TITLE
Record dependency of default version sql func on the extension

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1905,7 +1905,7 @@ find_versions_to_apply(ExtensionControlFile *pcontrol, const char **versionName)
 }
 
 static void
-recordSqlFunctionDependencies(char *extensionName,
+record_sql_function_dependencies(char *extensionName,
 								 const char *versionName,
 								 List *updateVersions,
 								 ObjectAddress address)
@@ -2184,14 +2184,14 @@ CreateExtensionInternal(char *extensionName,
 		ctlfunc.objectSubId = 0;
 		recordDependencyOn(&address, &ctlfunc, DEPENDENCY_NORMAL);
 
-		recordSqlFunctionDependencies(extensionName, versionName, updateVersions, address);
+		record_sql_function_dependencies(extensionName, versionName, updateVersions, address);
 
 		/* Record dependencies such that default version can be installed after a pg_dump */
 		if (pcontrol->default_version)
 		{
 			const char *defaultVersion = pcontrol->default_version;
 			updateVersions = find_versions_to_apply(pcontrol, &defaultVersion);
-			recordSqlFunctionDependencies(extensionName, defaultVersion, updateVersions, address);
+			record_sql_function_dependencies(extensionName, defaultVersion, updateVersions, address);
 		}
 	}
 
@@ -5020,7 +5020,7 @@ pg_tle_set_default_version(PG_FUNCTION_ARGS)
 		SET_TLEEXT;
 		updateVersions = find_versions_to_apply(control, &defaultVersion);
 		UNSET_TLEEXT;
-		recordSqlFunctionDependencies(extname, defaultVersion, updateVersions, extAddress);
+		record_sql_function_dependencies(extname, defaultVersion, updateVersions, extAddress);
 	}
 
 	/* flag that we are done manipulating pg_tle artifacts */

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1927,9 +1927,8 @@ record_sql_function_dependencies(char *extensionName,
 	}
 
 	/*
-		* If necessary update scripts are found, record dependency on each
-		* script
-		*/
+	 * If necessary update scripts are found, record dependency on each script
+	 */
 	if (updateVersions != NULL)
 	{
 		const char *oldVersionName = versionName;
@@ -2186,10 +2185,14 @@ CreateExtensionInternal(char *extensionName,
 
 		record_sql_function_dependencies(extensionName, versionName, updateVersions, address);
 
-		/* Record dependencies such that default version can be installed after a pg_dump */
+		/*
+		 * Record dependencies such that default version can be installed
+		 * after a pg_dump
+		 */
 		if (pcontrol->default_version)
 		{
 			const char *defaultVersion = pcontrol->default_version;
+
 			updateVersions = find_versions_to_apply(pcontrol, &defaultVersion);
 			record_sql_function_dependencies(extensionName, defaultVersion, updateVersions, address);
 		}
@@ -4906,7 +4909,7 @@ pg_tle_set_default_version(PG_FUNCTION_ARGS)
 	ExtensionControlFile *control;
 	char	   *filename;
 	List	   *updateVersions;
-	Oid         extensionOid;
+	Oid			extensionOid;
 	ObjectAddress extAddress;
 
 	if (PG_ARGISNULL(0))
@@ -5006,9 +5009,9 @@ pg_tle_set_default_version(PG_FUNCTION_ARGS)
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
 
-	/* 
-	 * When default version is updated we update the dependencies so that pg_dump
-	 * can maintain the correct order.
+	/*
+	 * When default version is updated we update the dependencies so that
+	 * pg_dump can maintain the correct order.
 	 */
 	extensionOid = get_extension_oid(extname, true);
 	if (extensionOid != InvalidOid)

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -17,8 +17,9 @@
 # 1. Install and create a regular TLE
 # 2. Install and create a TLE with an indirect version upgrade path
 # 3. Install and create a TLE that depends on another TLE with an indirect version
-# 4. Create a custom data type
-# 5. Create a custom operator
+# 4. Install two versions of a TLE and create the non-default version
+# 5. Create a custom data type
+# 6. Create a custom operator
 
 use strict;
 use warnings;
@@ -208,7 +209,56 @@ like  ($stdout, qr/1/, 'select_tle_function');
 $node->psql($testdb, 'SELECT test_cascade_dependency_func_2()', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/-1/, 'select_tle_function');
 
-# 4. Create a custom data type
+# 4. Install two versions of a TLE and create the non-default version
+
+$node->psql(
+    $testdb, qq[
+    SELECT pgtle.install_extension
+    (
+      'test_non_default_version',
+      '1.0',
+      'Test TLE Functions',
+    \$_pgtle_\$
+      CREATE OR REPLACE FUNCTION test_non_default_version()
+      RETURNS INT AS \$\$
+      (
+        SELECT 1
+      )\$\$ LANGUAGE sql;
+    \$_pgtle_\$
+    );
+    ], stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'install_tle');
+
+$node->psql(
+    $testdb, qq[
+    SELECT pgtle.install_extension_version_sql
+    (
+      'test_non_default_version',
+      '1.1',
+    \$_pgtle_\$
+      CREATE OR REPLACE FUNCTION test_non_default_version()
+      RETURNS INT AS \$\$
+      (
+        SELECT 2
+      )\$\$ LANGUAGE sql;
+    \$_pgtle_\$
+    );
+    ], stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'install_tle_update_path');
+
+$node->psql(
+    $testdb, qq[
+    SELECT default_version FROM pgtle.available_extensions() WHERE name = 'test_non_default_version';
+    ], stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/1.0/, 'verify default version');
+
+$node->psql($testdb, "CREATE EXTENSION test_non_default_version VERSION '1.1'", stdout => \$stdout, stderr => \$stderr);
+like  ($stderr, qr//, 'create_tle');
+$node->psql($testdb, 'SELECT test_non_default_version()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/2/, 'select_tle_function');
+
+
+# 5. Create a custom data type
 
 $node->psql($testdb, 'SELECT pgtle.create_shell_type(\'public\', \'test_citext\')', stdout => \$stdout, stderr => \$stderr);
 like  ($stderr, qr//, 'create_shell_type');
@@ -239,7 +289,7 @@ like  ($stderr, qr//, 'insert_custom_data_type');
 $node->psql($testdb, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/TEST/, 'select_custom_data_type');
 
-# 5. Create a custom data operator
+# 6. Create a custom data operator
 
 $node->psql($testdb, qq[CREATE FUNCTION public.test_citext_cmp(l bytea, r bytea) RETURNS int AS
     \$\$
@@ -321,12 +371,25 @@ like  ($stdout, qr/1/, 'select_tle_function_from_restored_db_3');
 $node->psql($restored_db, 'SELECT test_cascade_dependency_func_2()', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/-1/, 'select_tle_function_from_restored_db_3');
 
-# 4. Verify custom data type
+# 4. Verify non-default version TLE installed (the default version should be restored)
+
+$node->psql($restored_db,
+    "SELECT count(*) FROM pgtle.available_extension_versions() WHERE name = 'test_non_default_version'",
+    stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/2/, 'number_of_available_extension_versions');
+$node->psql($restored_db,
+    "SELECT version FROM pgtle.available_extension_versions() WHERE name = 'test_non_default_version' ORDER BY version",
+    stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/1\.0\n1\.1/, 'available_extension_versions');
+$node->psql($restored_db, 'SELECT test_non_default_version()', stdout => \$stdout, stderr => \$stderr);
+like  ($stdout, qr/1/, 'select_tle_function');
+
+# 5. Verify custom data type
 
 $node->psql($restored_db, 'SELECT * FROM test_dt;', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/TEST/, 'select_custom_data_type_from_restored_db');
 
-# 5. Verify custom data operator
+# 6. Verify custom data operator
 
 $node->psql($restored_db, 'SELECT (c1 = c1) as c2 from test_dt', stdout => \$stdout, stderr => \$stderr);
 like  ($stdout, qr/t/, 'operator_from_restored_db');


### PR DESCRIPTION
Issue #245

Description of changes:
Records dependencies of default version sql functions on the TLE. This fixes failures during pg_dump/pg_restore due to `<extensionName>--<defaultVersion>.sql` function being created after the extension in `pg_dump` (see #245 for details).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
