### PR TITLE
Allow superuser to ALTER OWNER of datatype functions

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4315,7 +4315,9 @@ _PU_HOOK
 			{
 				AlterOwnerStmt *stmt = (AlterOwnerStmt *) pu_parsetree;
 
-				if (!IsBinaryUpgrade && stmt->objectType == OBJECT_FUNCTION)
+				if (!IsBinaryUpgrade &&
+					!superuser() &&
+					stmt->objectType == OBJECT_FUNCTION)
 				{
 					ObjectAddress address;
 					Relation	relation;

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -298,7 +298,7 @@ like  ($stderr, qr//, 'create_new_db');
 
 # Restore freshly created db with psql -d newdb -f olddb.sql
 $node->command_ok(
-    [ 'psql',  '-d', $restored_db, '-f', $dumpfilename ],
+    [ 'psql',  '-d', $restored_db, '-f', $dumpfilename, '-v', 'ON_ERROR_STOP=1' ],
     'restore new db from sql dump'
 );
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/pg_tle/issues/249

Description of changes: Allow superuser to ALTER OWNER of datatype functions. Needed to unblock pg_dump/pg_restore of custom datatypes. pg_restore won't succeed for non-superuser roles regardless since create extension pg_tle requires superuser.

A fix for 002_pg_tle_dump_restore.pl is included. With the updated test, the original code fails as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.