### PR TITLE
Block postmaster startup if clientauth background workers fail to register

### DIFF
--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -339,6 +339,10 @@ clientauth_init(void)
 		RegisterBackgroundWorker(&worker);
 	}
 
+    /*
+     * Check the backgroud worker registered list.
+     * If any clientauth workers failed to register, then throw an error.
+     */
 	slist_foreach(siter, &BackgroundWorkerList)
 	{
 		RegisteredBgWorker *rw;

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -339,10 +339,10 @@ clientauth_init(void)
 		RegisterBackgroundWorker(&worker);
 	}
 
-    /*
-     * Check the backgroud worker registered list.
-     * If any clientauth workers failed to register, then throw an error.
-     */
+	/*
+	 * Check the backgroud worker registered list. If any clientauth workers
+	 * failed to register, then throw an error.
+	 */
 	slist_foreach(siter, &BackgroundWorkerList)
 	{
 		RegisteredBgWorker *rw;

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -354,7 +354,7 @@ clientauth_init(void)
 	{
 		ereport(ERROR,
 				errmsg("\"%s.clientauth\" feature was not able to create background workers", PG_TLE_NSPNAME),
-				errhint("Consider increasing max_worker_processes or reducing other background workers."));
+				errhint("Consider increasing max_worker_processes or decreasing pgtle.clientauth_num_parallel_workers."));
 	}
 }
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/pg_tle/issues/252

Description of changes: On init, check if clientauth's workers have been added to the registration list. If any are missing then fail postmaster startup. Emit an error for administrator to check `max_worker_processes` and `pgtle.clientauth_num_parallel_workers`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
