### PR TITLE
Add example of ndistinct computation

### DIFF
--- a/examples/ndistinct/README.md
+++ b/examples/ndistinct/README.md
@@ -1,0 +1,115 @@
+## Calculating N-distinct elements
+
+During ```ANALYZE```, the ```n_distinct``` value of a column is calculated as either a fixed value or a ratio of the number of distinct values over the total number of rows. The fixed value is always represented as a positive number, while the ratio will be represented as a negative number. This value is visible in the n_distinct column of the ```pg_stats``` catalog view and used by the PostgreSQL query optimizer for planning. For more, refer to the PostgreSQL [[documentation]](https://www.postgresql.org/docs/current/view-pg-stats.html]).
+
+The ```ANALYZE``` command will usually calculate an optimal ```n_distinct```. However, as the table grows very large and the data has higher variability, the less likely the ```n_distinct``` value can be calculated with an optimal value. Increasing [[statistics target]](https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-DEFAULT-STATISTICS-TARGET) for an ```ANALYZE``` command allows more rows and pages to be sampled, but there is a limit to how much this value can be set to.
+
+To overcome such as scenario, PostgreSQL provides users the ability to set an ```n_distinct``` value on a column to be used by ```ANALYZE```. This can be done by a DBA by using a SQL ```DISTINCT``` to calculate the number of distinct values in a column and then setting this value using the ```ALTER TABLE ... ALTER COLUMN SET (n_distinct =)``` command.
+
+This extension simplifies this task by providing a single function that calculates the n_distinct and performs the column alteration. This function can also be scheduled as part of periodic maintenance.
+
+To perform the n_distinct calculation, the [[HyperLogLog]](https://github.com/citusdata/postgresql-hll) extension is used. The advantage of using ```HLL``` is that it's much more efficient than a SQL sequential scan, albeit with a small estimation error.
+
+### Install Prerequisites
+---
+- [postgresql-hll](https://github.com/citusdata/postgresql-hll)
+- [plrust](https://github.com/tcdi/plrust)
+
+### Installation
+---
+To install the extension, run the [`ndistinct.sql`](https://github.com/aws/pg_tle/blob/main/examples/ndistinct/ndistinct.sql) file in the desired database.
+
+```sh
+psql -d postgres -f ndistinct.sql
+```
+
+### Functions
+```set_ndistinct(chosen_tablenames text[],  min_table_cardinality int = 2000000,  include_foreign bool DEFAULT false, table_batch_size int DEFAULT 1, dry_run BOOL DEFAULT true)```:
+
+Sets the ```n_distinct``` on all considered columns of a table. It is important to run ```ANALYZE``` before and after running this function. This is because there needs to be a minimal set of stats to determine if a columns should be considered for analysis. Running the ```ANALYZE``` after the function call is required to allow the n_distinct value to be used by the optimizer.
+
+```chosen_tablenames```:
+Required. This is a list of tables to set a per column n_distinct value for. i.e. 
+```select set_ndistinct(array['schema1.table1', 'schema2.tabl2']);```
+
+A wildcard can also be supplied, i.e.
+```select set_ndistinct(array['schema1.tabl*', 'schema2.*']);```
+
+In the above example, all tables in schema1 that have a prefix ```tabl``` and all tables in
+```schema2``` will be considered.
+
+
+```min_table_cardinality```:
+Default = ```2000000```. Only tables that have this many rows will be considered for setting ndistinct.
+
+ ```include_foreign ```:
+Default = ```false```. Change to ```true``` to set ndistinct on foreign tables.
+
+```table_batch_size```:
+Default = ```1```. All columns in a table are analyzed in this many batches. Setting this value higher than ```1``` is useful if there are many columns in a table to be analyzed leading to high memory consumption of this function.
+
+```current_ndistinct```:
+Default = ```-.95```. Any column that has an ```n_distinct``` lower than this value will be skipped. This is because a ```-1``` n_distinct indicates the data in the column is entrirely unique and should not be considered.
+
+```dry_run```:
+Default = ```true```. This will scan the tables and compute an n_distinct value, but will not perform the ```ALTER TABLE..ALTER COLUMN``` command.
+### Example
+In the below contrived example, the ```default_statistics_target``` is set to a low value to produce a suboptimal n_distinct value. We then run ```set_ndistinct``` to calculate a better n_distinct value.
+The example also compares the time it takes to calculate n_distinct using the ```set_ndistinct``` function instead of a SQL ```COUNT(DISTINCT)```, which is ~7 seconds vs ~1 minute.
+```
+DROP TABLE t;
+CREATE TABLE t as SELECT floor(random() * 100000) as id from generate_series(1, 50000000);
+SET default_statistics_target = 1;
+ANALYZE t;
+SELECT tablename, attname, n_distinct::numeric as n_distinct FROM pg_stats WHERE tablename in ('t');
+\timing
+SELECT set_ndistinct(
+        ARRAY['public.t'],
+        dry_run => false,
+        current_ndistinct => -1.1
+);
+\timing
+ANALYZE t;
+SELECT tablename, attname, n_distinct::numeric as n_distinct FROM pg_stats WHERE tablename in ('t');
+\timing
+SELECT COUNT(DISTINCT id) FROM t;
+\timing
+```
+
+```
+DROP TABLE
+SELECT 50000000
+SET
+ANALYZE
+ tablename | attname | n_distinct 
+-----------+---------+------------
+ t         | id      |         -1
+(1 row)
+
+Timing is on.
+psql:/tmp/foo.sql:11: NOTICE:  Running batch 1 for table public.t
+psql:/tmp/foo.sql:11: NOTICE:  Current n_distinct for column id is -1
+running: ALTER TABLE public.t ALTER COLUMN id SET (n_distinct = 100780);
+
+ set_ndistinct 
+---------------
+ 
+(1 row)
+
+Time: 7617.442 ms (00:07.617)
+Timing is off.
+ANALYZE
+ tablename | attname | n_distinct 
+-----------+---------+------------
+ t         | id      |     100780
+(1 row)
+
+Timing is on.
+ count
+--------
+ 100000
+(1 row)
+
+Time: 61614.802 ms (01:01.615)
+Timing is off.
+```

--- a/examples/ndistinct/ndistinct.sql
+++ b/examples/ndistinct/ndistinct.sql
@@ -1,0 +1,252 @@
+CREATE EXTENSION IF NOT EXISTS pg_tle;
+CREATE EXTENSION IF NOT EXISTS plrust;
+CREATE EXTENSION IF NOT EXISTS hll;
+
+--
+-- Trusted language extension for ndistinct-1.0
+--
+-- To use, execute this file in your desired database to install the extension.
+--
+
+SELECT pgtle.install_extension
+(
+    'ndistinct',
+    '1.0',
+    'extension for efficient ndistinct calculation',
+$_pg_tle_$
+DROP FUNCTION IF EXISTS set_ndistinct;
+CREATE FUNCTION set_ndistinct(
+        chosen_tablenames TEXT[],
+        min_table_cardinality INT DEFAULT 2000000,
+        include_foreign BOOL DEFAULT false,
+        table_batch_size INT DEFAULT 1,
+        current_ndistinct FLOAT DEFAULT -.95,
+        dry_run BOOL DEFAULT true)
+    RETURNS VOID
+AS
+$$
+    /*
+        Define all globals here
+     */
+
+    /* The Min n_distinct value possible */
+    let MIN_NDISTINCT = -1.0;
+
+    /* the multiplier for determining to use scale vs fixed ndistinct */
+    let RELTUPLES_MULTIPLIER = 0.10;
+
+    /* The main query to extract candidate columns in batches */
+    let BATCHES_QUERY = r#"
+        WITH all_expressions AS (
+            SELECT 
+                s.schemaname, 
+                s.tablename, 
+                s.attname,
+                catt.attnum,
+                catt.reltuples,
+                s.n_distinct current_n_distinct,
+                'round(hll_cardinality(hll_add_agg(hll_hash_' || catt.hll_type || '("' || attname || '"))))' AS n_distinct_expr
+            FROM 
+            (
+                WITH t AS (select distinct unnest($1) as chosen_tablename)
+                SELECT s.* FROM pg_stats as s, t
+                WHERE s.schemaname || '.' || s.tablename like t.chosen_tablename
+            ) as s
+            INNER JOIN (
+                SELECT 
+                    c.relname, 
+                    n.nspname, 
+                    c.relkind, 
+                    c.relispartition,
+                    a.attname AS a_attname, 
+                    a.attnum,
+                    c.reltuples,
+                    CASE WHEN t.typname = 'int4' THEN 'integer' 
+                         WHEN t.typname IN ('text', 'char', 'name') THEN 'text' 
+                         WHEN t.typname = 'int2' THEN 'smallint' 
+                         WHEN t.typname IN ('int8', 'oid') THEN 'bigint' 
+                         WHEN t.typname = 'bool' THEN 'boolean' 
+                         WHEN t.typname = 'bytea' THEN 'bytea' 
+                         ELSE 'any' END AS hll_type
+                FROM 
+                    pg_class c 
+                    INNER JOIN pg_attribute a ON c.oid = a.attrelid 
+                    INNER JOIN pg_namespace n ON n.oid = c.relnamespace 
+                    INNER JOIN pg_type t ON (a.atttypid = t.oid)
+                    ) catt ON (
+                        catt.relname = s.tablename 
+                        AND catt.a_attname = s.attname
+                    ) 
+                    WHERE 
+                        s.n_distinct > $5
+                        AND -- ignore the distinct or nearly-distinct columns.  ANALYZE may have found a few (true) duplicates
+                        (
+                            catt.reltuples >= $2
+                            OR catt.relispartition
+                        ) 
+                        AND -- Don't restrict size of partitions
+                            catt.nspname NOT LIKE 'pg_%' 
+                        AND 
+                            catt.nspname <> 'information_schema' 
+                        AND (
+                            catt.relkind IN ('r', 'm', 'p') 
+                            OR -- relations that have attribute stats overrides
+                                (
+                                    catt.relkind = 'f' 
+                                    AND $3
+                                )
+                            )
+            ), 
+        all_expressions_batched as (
+            SELECT 
+                schemaname, 
+                tablename, 
+                attname,
+                reltuples,
+                n_distinct_expr,
+                current_n_distinct, 
+                NTILE($4) OVER (
+                    PARTITION BY schemaname, tablename
+                ) AS batch_no 
+            FROM 
+                all_expressions order by schemaname, tablename, attnum asc
+        ) 
+        SELECT
+            DISTINCT 
+                schemaname||'.'||tablename as tablename,
+                array_agg(attname::text) over (
+                    partition by schemaname,
+                    tablename, 
+                    batch_no
+                ) AS columns,
+                array_agg(current_n_distinct) over (
+                    partition by schemaname,
+                    tablename, 
+                    batch_no
+                ) AS current_n_distinct,
+                reltuples::float as reltuples,
+                'SELECT '||E'\n'||'array[' || string_agg(n_distinct_expr, ','||E'\n')
+                over ( partition by schemaname, tablename, batch_no ) || '] '||E'\n'||'as ndistinct FROM ' || schemaname || '.' || tablename AS query,
+                batch_no 
+        FROM
+            all_expressions_batched;
+"#;
+
+    /* 
+        Create an SPI client and run the query to get all the batches.
+    */
+    Spi::connect(|mut client| {
+        let mut all_batches = client.select(
+            BATCHES_QUERY,
+            None, 
+            Some(vec![
+                        (
+                            PgBuiltInOids::TEXTARRAYOID.oid(),
+                            chosen_tablenames.into_datum(),
+                        ),
+                        (
+                            PgBuiltInOids::INT4OID.oid(),
+                            min_table_cardinality.into_datum(),
+                        ),
+                        (
+                            PgBuiltInOids::BOOLOID.oid(),
+                            include_foreign.into_datum(),
+                        ),
+                        (
+                            PgBuiltInOids::INT4OID.oid(),
+                            table_batch_size.into_datum(),
+                        ),
+                        (
+                            PgBuiltInOids::FLOAT8OID.oid(),
+                            current_ndistinct.into_datum(),
+                        ),
+                    ]
+            ))?;
+        
+        /*
+            loop through all the batches and construct the alter table... alter column
+            commands.
+        */
+        for batches_rows in all_batches {
+            let tablename = batches_rows["tablename"].
+                                value::<String>().expect("cannot get tablename as a string").unwrap();
+            let hllquery = batches_rows["query"].
+                                value::<String>().expect("cannot get hllquery as a string").unwrap();
+            let batchno = batches_rows["batch_no"].
+                                value::<i32>().expect("cannot get batchno as a integer").unwrap();
+            let reltuples = batches_rows["reltuples"].
+                                value::<f64>().expect("cannot get reltuples as a integer").unwrap();
+
+            if reltuples == 0.0 {
+                notice!("Table {} has 0 rows - skipping", tablename);
+                continue;
+            }
+
+            if !dry_run {
+                notice!("Running batch {} for table {}", batchno, tablename);
+            } else {
+                notice!("DRY RUN ONLY - Running batch {} for table {}", batchno, tablename);
+            }
+
+            let hll_results = client.select(&hllquery, None, None)?;
+
+            for (i, batch_row) in hll_results.enumerate() {
+                let columns = batches_rows["columns"].
+                                value::<Array<&str>>().expect("Cannot get columns as a string").unwrap();
+                let current_ndistinct = batches_rows["current_n_distinct"].
+                                value::<Array<f32>>().expect("Cannot get current_ndistinct as a integer").unwrap();
+                let ndistinct = batch_row["ndistinct"].
+                                value::<Array<f64>>().expect("Cannot get ndistinct as a float").unwrap();
+                let mut current_ndistinct_all : Vec<f32> = vec![];
+                let mut ndistinct_all : Vec<f64> = vec![];
+
+                for ndistinct in ndistinct {
+                    ndistinct_all.push(ndistinct.unwrap());
+                }
+
+                for current_ndistinct in current_ndistinct {
+                    current_ndistinct_all.push(current_ndistinct.unwrap());
+                }
+
+                assert_eq!(columns.len(), current_ndistinct_all.len());
+
+                for column in columns {
+                    let mut ndistinct_final;
+
+                    ndistinct_final = ndistinct_all[i];
+
+                    /*
+                     * If more than 10% (RELTUPLES_MULTIPLIER) of the total rows are distinct,
+                     * set ndistinct_final to a scale ( negative decimal ) rather than a fixed value.
+                     * See https://github.com/postgres/postgres/blob/master/src/backend/commands/analyze.c#L2275-L2281
+                     */
+                    let mut reltuples2 = reltuples * RELTUPLES_MULTIPLIER;
+                    if (ndistinct_all[i] >= reltuples2) {
+                        ndistinct_final = f64::max(MIN_NDISTINCT, MIN_NDISTINCT * (ndistinct_all[i] / reltuples));
+                    }
+
+                    let alter_sql = format!("ALTER TABLE {} ALTER COLUMN {} SET (n_distinct = {});",
+                                            tablename,
+                                            column.unwrap(),
+                                            ndistinct_final);
+                    if !dry_run {
+                        client.update(&alter_sql, None, None);
+                    }
+
+                    notice!("Current n_distinct for column {} is {}\nrunning: {}\n",
+                            column.unwrap(),
+                            current_ndistinct_all[i],
+                            alter_sql);
+                }
+            }
+        }
+        Ok(None)
+    }
+    )
+$$ LANGUAGE plrust STRICT VOLATILE;
+$_pg_tle_$,
+ARRAY['plrust', 'hll']
+);
+
+CREATE EXTENSION ndistinct;
+


### PR DESCRIPTION
Description of changes: Add an example of a pl/rust function that calculates and sets the n_distinct value of a column.
The calculation is performed using the HLL [1] extension.

[1] https://github.com/citusdata/postgresql-hll

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
