### PR TITLE
Erase shared memory entry after each clientauth/passcheck request

### DIFF
--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -737,6 +737,7 @@ clientauth_hook(Port *port, int status)
 	/* Copy results of BGW processing from shared memory */
 	snprintf(error_msg, CLIENT_AUTH_USER_ERROR_MAX_STRLEN, "%s", clientauth_ss->requests[idx].error_msg);
 	error = clientauth_ss->requests[idx].error;
+
 	/* Erase data about this request from shared memory now that we're done */
 	memset(&clientauth_ss->requests[idx].port_info, 0, sizeof(PortSubset));
 	clientauth_ss->requests[idx].status = 0;

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -737,6 +737,12 @@ clientauth_hook(Port *port, int status)
 	/* Copy results of BGW processing from shared memory */
 	snprintf(error_msg, CLIENT_AUTH_USER_ERROR_MAX_STRLEN, "%s", clientauth_ss->requests[idx].error_msg);
 	error = clientauth_ss->requests[idx].error;
+	/* Erase data about this request from shared memory now that we're done */
+	memset(&clientauth_ss->requests[idx].port_info, 0, sizeof(PortSubset));
+	clientauth_ss->requests[idx].status = 0;
+	memset(clientauth_ss->requests[idx].error_msg, 0, sizeof(char) * CLIENT_AUTH_USER_ERROR_MAX_STRLEN);
+	clientauth_ss->requests[idx].error = false;
+
 	clientauth_ss->requests[idx].available_entry = true;
 	LWLockRelease(clientauth_ss->lock);
 	ConditionVariableSignal(clientauth_ss->requests[idx].available_entry_cv_ptr);

--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -342,6 +342,7 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 	error = passcheck_ss->error;
 	snprintf(error_msg, PASSCHECK_ERROR_MSG_MAX_STRLEN, "%s", passcheck_ss->error_msg);
 	snprintf(error_hint, PASSCHECK_ERROR_MSG_MAX_STRLEN, "%s", passcheck_ss->error_hint);
+
 	/* Erase data about this request from shared memory now that we're done */
 	memset(&passcheck_ss->data, 0, sizeof(PasswordCheckHookData));
 	passcheck_ss->error = false;

--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -342,6 +342,11 @@ passcheck_check_password_hook(const char *username, const char *shadow_pass, Pas
 	error = passcheck_ss->error;
 	snprintf(error_msg, PASSCHECK_ERROR_MSG_MAX_STRLEN, "%s", passcheck_ss->error_msg);
 	snprintf(error_hint, PASSCHECK_ERROR_MSG_MAX_STRLEN, "%s", passcheck_ss->error_hint);
+	/* Erase data about this request from shared memory now that we're done */
+	memset(&passcheck_ss->data, 0, sizeof(PasswordCheckHookData));
+	passcheck_ss->error = false;
+	memset(passcheck_ss->error_msg, 0, sizeof(char) * PASSCHECK_ERROR_MSG_MAX_STRLEN);
+	memset(passcheck_ss->error_hint, 0, sizeof(char) * PASSCHECK_ERROR_MSG_MAX_STRLEN);
 
 	passcheck_ss->available_entry = true;
 	LWLockRelease(passcheck_ss->lock);


### PR DESCRIPTION
Issue #, if available:

Description of changes: After each clientauth and passcheck request is completed by the background worker, erase the shared memory entry to prevent sensitive information from persisting longer than necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
