### PR TITLE
Quote clientauth identifiers

### DIFF
--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -578,18 +578,22 @@ clientauth_launcher_run_user_functions(bool *error, char (*error_msg)[CLIENT_AUT
 		Datum		hookargs[SPI_NARGS_2];
 		char		hooknulls[SPI_NARGS_2];
 
+		/*
+		 * func_name is already using quote_identifier from when it was
+		 * assembled
+		 */
 		query = psprintf("SELECT * FROM %s($1::%s.clientauth_port_subset, $2::pg_catalog.int4)",
 						 func_name,
 						 quote_identifier(PG_TLE_NSPNAME));
 
-		port_subset_str = psprintf("(%d,\"%s\",\"%s\",%d,%d,\"%s\",\"%s\")",
+		port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s)",
 								   port->noblock,
-								   port->remote_host,
-								   port->remote_hostname,
+								   quote_identifier(port->remote_host),
+								   quote_identifier(port->remote_hostname),
 								   port->remote_hostname_resolv,
 								   port->remote_hostname_errcode,
-								   port->database_name,
-								   port->user_name);
+								   quote_identifier(port->database_name),
+								   quote_identifier(port->user_name));
 
 		hookargs[0] = CStringGetTextDatum(port_subset_str);
 		hookargs[1] = Int32GetDatum(*status);

--- a/test/t/004_pg_tle_clientauth.pl
+++ b/test/t/004_pg_tle_clientauth.pl
@@ -26,6 +26,7 @@
 ### 12. Users cannot log in when pgtle.enable_clientauth = 'require' and pg_tle is not installed on pgtle.clientauth_database_name
 ### 13. Rejects connections when no schema qualified function is found
 ### 14. Database does not come up if clientauth workers fail to start
+### 15. Malformed strings cannot be used for SQL injection
 
 use strict;
 use warnings;
@@ -35,6 +36,7 @@ use PostgreSQL::Test::Utils;
 use Test::More;
 
 my $psql_err = '';
+my $psql_out = '';
 my $node = PostgreSQL::Test::Cluster->new('clientauth_test');
 
 $node->init;
@@ -231,6 +233,7 @@ like($psql_err, qr/FATAL:  table, schema, and proname must be present in "pgtle.
 $node->command_ok(
     ['psql', '-c', 'select;'],
     "can still connect if database is in pgtle.clientauth_databases_to_skip");
+$node->psql('postgres', qq[TRUNCATE pgtle.feature_info], on_error_die => 1);
 
 ### 14. Database does not come up if clientauth workers fail to start
 $node->append_conf('postgresql.conf', qq(pgtle.clientauth_num_parallel_workers = 64));
@@ -241,6 +244,40 @@ $node->command_fails(
 $node->append_conf('postgresql.conf', qq(pgtle.clientauth_num_parallel_workers = 60));
 $node->append_conf('postgresql.conf', qq(max_worker_processes = 63));
 $node->restart;
+
+### 15. Malformed strings cannot be used for SQL injection
+$node->psql('postgres', q[
+    CREATE FUNCTION reject_testuser(port pgtle.clientauth_port_subset, status integer) RETURNS void AS $$
+        BEGIN
+            -- RAISE EXCEPTION '%', port.remote_hostname;
+            IF port.user_name = 'testuser' THEN
+                RAISE EXCEPTION 'testuser is not allowed to connect';
+            END IF;
+        END
+    $$ LANGUAGE plpgsql], on_error_die => 1);
+$node->psql('postgres', qq[SELECT pgtle.register_feature('reject_testuser', 'clientauth')], on_error_die => 1);
+# Create role with name "
+$node->psql('postgres', qq[CREATE ROLE """" LOGIN], on_error_die => 1);
+# Create role with name ""
+$node->psql('postgres', qq[CREATE ROLE """""" LOGIN], on_error_die => 1);
+# Create database with name "
+$node->psql('postgres', qq[CREATE DATABASE """"], on_error_die => 1);
+# Create database with name ""
+$node->psql('postgres', qq[CREATE DATABASE """"""], on_error_die => 1);
+
+# Make sure we can connect to all of these
+$node->psql('"', 'SELECT current_database()', stdout => \$psql_out, on_error_die => 1);
+like($psql_out, qr/^"$/,
+    "database with double quote in name can connect");
+$node->psql('""', 'SELECT current_database()', stdout => \$psql_out, on_error_die => 1);
+like($psql_out, qr/^""$/,
+    "database with two double quotes in name can connect");
+$node->psql('not_excluded', 'SELECT current_user', extra_params => ['-U', '"'], stdout => \$psql_out, on_error_die => 1);
+like($psql_out, qr/^"$/,
+    "role with double quote in name can connect");
+$node->psql('not_excluded', 'SELECT current_user', extra_params => ['-U', '""'], stdout => \$psql_out, on_error_die => 1);
+like($psql_out, qr/^""$/,
+    "role with two double quotes in name can connect");
 
 $node->stop;
 done_testing();


### PR DESCRIPTION
Issue #, if available:

Description of changes: Use quote_identifier to prevent SQL injections and support identifiers containing double quote characters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
