### PR TITLE
Init passcheck worker_handle to NULL

### DIFF
--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -164,7 +164,7 @@ static void
 passcheck_check_password_hook(const char *username, const char *shadow_pass, PasswordType password_type, Datum validuntil_time, bool validuntil_null)
 {
 	BackgroundWorker worker;
-	BackgroundWorkerHandle *worker_handle;
+	BackgroundWorkerHandle *worker_handle = NULL;
 	bool		error;
 	char		error_msg[PASSCHECK_ERROR_MSG_MAX_STRLEN];
 	char		error_hint[PASSCHECK_ERROR_MSG_MAX_STRLEN];


### PR DESCRIPTION
Description of changes:

Needed so that passcheck can accurately check whether the worker has been registered (https://github.com/aws/pg_tle/blob/main/src/passcheck.c#L306)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
