### PR TITLE
Allow mixed case in pgtle.clientauth_users_to_skip and pgtle.clientauth_databases_to_skip

### DIFF
--- a/src/feature.c
+++ b/src/feature.c
@@ -137,7 +137,7 @@ check_string_in_guc_list(const char *str, const char *guc_var, const char *guc_n
 	ListCell   *lc;
 
 	guc_copy = pstrdup(guc_var);
-	if (!SplitIdentifierString(guc_copy, ',', &guc_list))
+	if (!SplitGUCList(guc_copy, ',', &guc_list))
 		elog(ERROR, "could not parse %s", guc_name);
 
 	foreach(lc, guc_list)

--- a/test/t/004_pg_tle_clientauth.pl
+++ b/test/t/004_pg_tle_clientauth.pl
@@ -255,6 +255,46 @@ $node->psql('postgres', q[
         END
     $$ LANGUAGE plpgsql], on_error_die => 1);
 $node->psql('postgres', qq[SELECT pgtle.register_feature('reject_testuser', 'clientauth')], on_error_die => 1);
+### 16. Allow mixedCase in pgtle.clientauth_users_to_skip
+$node->psql('postgres', 'CREATE ROLE \"testUser3\" LOGIN', stderr => \$psql_err);
+$node->psql('postgres', q[
+    CREATE FUNCTION reject_testUser3(port pgtle.clientauth_port_subset, status integer) RETURNS text AS $$
+        BEGIN
+            IF port.user_name = 'testUser3' THEN
+                RETURN 'testUser3 is not allowed to connect';
+            ELSE
+                RETURN '';
+            END IF;
+        END
+    $$ LANGUAGE plpgsql;]);
+$node->psql('postgres', qq[SELECT pgtle.register_feature('reject_testUser3', 'clientauth')]);
+$node->psql('postgres', 'select', extra_params => ['-U', 'testUser3'], stderr => \$psql_err);
+like($psql_err, qr/FATAL:  testUser3 is not allowed to connect/,
+    "clientauth function rejects testUser3");
+
+$node->append_conf('postgresql.conf', qq(pgtle.enable_clientauth = 'on'));
+$node->append_conf('postgresql.conf', qq(pgtle.clientauth_users_to_skip = 'testUser3'));
+$node->restart;
+
+$node->command_ok(
+    ['psql', '-U', 'testUser3', '-c', 'select;'],
+    "clientauth function does not reject testUser3 when testUser3 is in pgtle.clientauth_users_to_skip");
+### 17. Allow mixedCase in pgtle.clientauth_databases_to_skip
+$node->psql('postgres', 'CREATE DATABASE \"mixedCaseDb\"');
+$node->append_conf('postgresql.conf', qq(pgtle.clientauth_users_to_skip = ''));
+$node->append_conf('postgresql.conf', qq(pgtle.clientauth_databases_to_skip = ''));
+$node->psql('postgres', 'SELECT pg_reload_conf();');
+
+$node->psql('mixedCaseDb', 'select', extra_params => ['-U', 'testUser3'], stderr => \$psql_err);
+like($psql_err, qr/FATAL:  testUser3 is not allowed to connect/,
+    "clientauth function rejects testUser3");
+
+$node->append_conf('postgresql.conf', qq(pgtle.clientauth_databases_to_skip = 'mixedCaseDb'));
+$node->psql('postgres', 'SELECT pg_reload_conf();');
+
+$node->command_ok(
+    ['psql', '-U', 'testUser3', '-c', 'select;'],
+    "clientauth function does not reject testUser3 when database is in pgtle.clientauth_databases_to_skip");
 # Create role with name "
 $node->psql('postgres', qq[CREATE ROLE """" LOGIN], on_error_die => 1);
 # Create role with name ""


### PR DESCRIPTION
…th_databases_to_skip

Issue #, if available: [265](https://github.com/aws/pg_tle/issues/265)

Description of changes: Allow mixed case in pgtle.clientauth_users_to_skip and pgtle.clientauth_databases_to_skip

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
