### PR TITLE
Refactor typo in 04_hooks.md doc

### DIFF
--- a/docs/04_hooks.md
+++ b/docs/04_hooks.md
@@ -345,7 +345,7 @@ $_pgtle_$
 To enable the `clientauth` hook, you will need to set `pgtle.enable_clientauth` to `on` or `require` and restart the database. For example:
 
 ```sql
-ALTER SYSTEM SET pgtle.enable_password_check TO 'on';
+ALTER SYSTEM SET pgtle.enable_clientauth TO 'on';
 ```
 
 Then restart the database (e.g. `pg_ctl restart`).


### PR DESCRIPTION
Update the SQL command to set enable_clientauth hook in the 2nd example in the hook doc.
It has a typo suggesting to activate enable_password_check hook instead.