### PR TITLE
Add note about libpq sslmode to clientauth docs

### DIFF
--- a/docs/04_hooks.md
+++ b/docs/04_hooks.md
@@ -342,6 +342,8 @@ $_pgtle_$
 );
 ```
 
+> **Note**: If the database client has set the `sslmode` parameter to `allow` or `prefer`, the client will automatically attempt to re-connect if the first connection fails. This will trigger the `clientauth` function twice, adding 2 to their failed connection attempts. See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) for more information.
+
 To enable the `clientauth` hook, you will need to set `pgtle.enable_clientauth` to `on` or `require` and restart the database. For example:
 
 ```sql

--- a/examples/client_lockout/README.md
+++ b/examples/client_lockout/README.md
@@ -2,6 +2,8 @@
 
 Locks out database users after 5 consecutive failed logins. Uses the `clientauth` hook.
 
+> **Note**: If the database client has set the `sslmode` parameter to `allow` or `prefer`, the client will automatically attempt to re-connect if the first connection fails. This will trigger the `clientauth` function twice, adding 2 to their failed connection attempts. See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) for more information.
+
 ### Installation
 ---
 To install the extension, configure the Postgres database target in `../env.ini`, then run `make install`.


### PR DESCRIPTION
Issue #, if available: #274

Description of changes: Add note about libpq sslmode to clientauth docs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
