### PR TITLE
Update column name for pgtle functions

### DIFF
--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -46,7 +46,7 @@ None.
 
 * `name`: The name of the extension.
 * `default_version`: The version of the extension to use when `CREATE EXTENSION` is called without a version.
-* `description`: A more detailed description about the extension.
+* `comment`: A more detailed description about the extension.
 
 #### Example
 
@@ -77,7 +77,7 @@ None.
 * `relocatable`: This is always `false` for a pg_tle-compatible extension.
 * `schema`: This is set if the extension must be installed into a specific schema.
 * `requires`: An array of extension names that this extension depends on.
-* `description`: A more detailed description about the extension.
+* `comment`: A more detailed description about the extension.
 
 #### Example
 


### PR DESCRIPTION
Issue #, if available: None

Description of changes: 
Updated [03_managing_extensions.md](https://github.com/aws/pg_tle/blob/main/docs/03_managing_extensions.md) to reflect the correct column names for `pgtle.available_extensions()` and `pgtle.available_extension_versions()`.

As shown below, the column name is `comment`:
```
test=# SELECT * FROM pgtle.available_extensions();
    name     | default_version |              comment              
-------------+-----------------+-----------------------------------```
```
and
```
test=# SELECT * FROM pgtle.available_extension_versions();
    name     | version | superuser | trusted | relocatable | schema | requires |              comment              
-------------+---------+-----------+---------+-------------+--------+----------+-----------------------------------
```

But in the doc, it said `description`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
