### PR TITLE
Update checkout to v4 and upload-artifacts to v4

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout pg_tle
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pg_tle
 

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -58,7 +58,7 @@ jobs:
   
       - name: Upload test artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-artifact-${{ matrix.os }}-${{ matrix.version }}
           path: |
@@ -86,7 +86,7 @@ jobs:
           # rm -f src/*.gcda src/*.gcno src/lcov*.info src/*.gcov src/.*.gcov src/*.gcov.out lcov_base.info lcov_test.info
 
       - name: Upload code coverage artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-artifact-${{ matrix.os }}-${{ matrix.version }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-artifact-${{ matrix.os }}-${{ matrix.version }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout pg_tle
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pg_tle
 


### PR DESCRIPTION
Description of changes: Our GH Actions are running on Node 16 which is being deprecated by GitHub. Update `checkout` and `upload-artifacts` from v3 to v4 which run on Node 20.

I tested this in my fork and verified that the behaviour is the same.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
