### PR TITLE
Fix build failure on Postgres master

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -578,4 +578,19 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 #define WAIT_EVENT_MESSAGE_QUEUE_RECEIVE WAIT_EVENT_MQ_RECEIVE
 #endif
 
+/*
+ * PostgreSQL version 18+
+ *
+ * b43100f changes BackgroundWorkerList from an slist to a dlist
+ */
+#if (PG_VERSION_NUM >= 180000)
+#define BGW_LIST_ITER dlist_iter
+#define BGW_LIST_FOREACH dlist_foreach
+#define BGW_LIST_CONTAINER dlist_container
+#else
+#define BGW_LIST_ITER slist_iter
+#define BGW_LIST_FOREACH slist_foreach
+#define BGW_LIST_CONTAINER slist_container
+#endif
+
 #endif							/* SET_USER_COMPAT_H */

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -241,7 +241,7 @@ void
 clientauth_init(void)
 {
 	BackgroundWorker worker;
-	dlist_iter	diter;
+	BGW_LIST_ITER bgw_iter;
 	int			num_registered_workers = 0;
 
 	/* Define our GUC parameters */
@@ -344,11 +344,12 @@ clientauth_init(void)
 	 * Check the backgroud worker registered list. If any clientauth workers
 	 * failed to register, then throw an error.
 	 */
-	dlist_foreach(diter, &BackgroundWorkerList)
+	BGW_LIST_FOREACH(bgw_iter, &BackgroundWorkerList)
 	{
 		RegisteredBgWorker *rw;
 
-		rw = dlist_container(RegisteredBgWorker, rw_lnode, diter.cur);
+		rw = BGW_LIST_CONTAINER(RegisteredBgWorker, rw_lnode, bgw_iter.cur);
+
 		if (strncmp(rw->rw_worker.bgw_type, clientauth_worker_name, BGW_MAXLEN) == 0)
 			num_registered_workers++;
 	}

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -241,7 +241,7 @@ void
 clientauth_init(void)
 {
 	BackgroundWorker worker;
-	slist_iter	siter;
+	dlist_iter	diter;
 	int			num_registered_workers = 0;
 
 	/* Define our GUC parameters */
@@ -344,11 +344,11 @@ clientauth_init(void)
 	 * Check the backgroud worker registered list. If any clientauth workers
 	 * failed to register, then throw an error.
 	 */
-	slist_foreach(siter, &BackgroundWorkerList)
+	dlist_foreach(diter, &BackgroundWorkerList)
 	{
 		RegisteredBgWorker *rw;
 
-		rw = slist_container(RegisteredBgWorker, rw_lnode, siter.cur);
+		rw = dlist_container(RegisteredBgWorker, rw_lnode, diter.cur);
 		if (strncmp(rw->rw_worker.bgw_type, clientauth_worker_name, BGW_MAXLEN) == 0)
 			num_registered_workers++;
 	}


### PR DESCRIPTION
Description of changes: [b43100f](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b43100f) changes BackgroundWorkerList from slist to dlist. Add compatibility macro for this.

Add REL_17_STABLE to the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
