### PR TITLE
Fix master branch ExecutorRunParams change CI failure

### DIFF
--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -593,4 +593,16 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 #define BGW_LIST_CONTAINER slist_container
 #endif
 
+/*
+ * Postgres version changes for ExecutorRun parameters
+ * Master branch commit 3eea7a0c97e removes the execute_once parameter
+ */
+#if (PG_VERSION_NUM >= 180000)
+#define EXECUTOR_RUN(queryDesc, direction, count, execute_once) \
+    ExecutorRun((queryDesc), (direction), (count))
+#else
+#define EXECUTOR_RUN(queryDesc, direction, count, execute_once) \
+    ExecutorRun((queryDesc), (direction), (count), (execute_once))
+#endif
+
 #endif							/* SET_USER_COMPAT_H */

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1173,7 +1173,7 @@ execute_sql_string(const char *sql)
 										dest, NULL, NULL, 0);
 
 				ExecutorStart(qdesc, 0);
-				ExecutorRun(qdesc, ForwardScanDirection, 0, true);
+				EXECUTOR_RUN(qdesc, ForwardScanDirection, 0, true);
 				ExecutorFinish(qdesc);
 				ExecutorEnd(qdesc);
 


### PR DESCRIPTION
**Issue #, if available:**

Postgres master branch commit [3eea7a0](https://github.com/postgres/postgres/commit/3eea7a0c97e94f9570af87317ce3f6a41eb62768) simplified the executor's parallel mode determination by:

Removing the execute_once parameter from ExecutorRun

Relying on QueryDesc.already_executed flag instead

Moving the logic to ExecutePlan

This API change in PostgreSQL master broke pg_tle's CI build because pg_tle was using the 4-parameter version of ExecutorRun.

**Description of changes:**
Added version-specific compatibility macro EXECUTOR_RUN that:

For PostgreSQL 18+ (master): Uses the new 3-parameter version

`ExecutorRun(queryDesc, direction, count)`

For PostgreSQL 17 and earlier: Uses the existing 4-parameter version with true

`ExecutorRun(queryDesc, direction, count, true)`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
