### PR TITLE
Added schema parameter to install_extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = pg_tle
-EXTVERSION = 1.4.1
+EXTVERSION = 1.5.0
 
 SCHEMA = pgtle
 MODULE_big = $(EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MODULE_big = $(EXTENSION)
 OBJS = src/tleextension.o src/guc-file.o src/feature.o src/passcheck.o src/uni_api.o src/datatype.o src/clientauth.o
 
 EXTRA_CLEAN	= src/guc-file.c pg_tle.control pg_tle--$(EXTVERSION).sql
-DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql pg_tle--1.0.4.sql pg_tle--1.0.4--1.1.1.sql pg_tle--1.1.0--1.1.1.sql pg_tle--1.1.1.sql pg_tle--1.1.1--1.2.0.sql pg_tle--1.2.0--1.3.0.sql pg_tle--1.3.0--1.3.3.sql pg_tle--1.3.3--1.3.4.sql pg_tle--1.3.4--1.4.0.sql pg_tle--1.4.0--1.4.1.sql
+DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql pg_tle--1.0.4.sql pg_tle--1.0.4--1.1.1.sql pg_tle--1.1.0--1.1.1.sql pg_tle--1.1.1.sql pg_tle--1.1.1--1.2.0.sql pg_tle--1.2.0--1.3.0.sql pg_tle--1.3.0--1.3.3.sql pg_tle--1.3.3--1.3.4.sql pg_tle--1.3.4--1.4.0.sql pg_tle--1.4.0--1.4.1.sql pg_tle--1.4.1--1.5.0.sql
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/pg_tle--1.4.1--1.5.0.sql
+++ b/pg_tle--1.4.1--1.5.0.sql
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_tle" to load this file. \quit
+
+DROP FUNCTION pgtle.install_extension
+(
+  name text,
+  version text,
+  description text,
+  ext text,
+  requires text[]
+);
+CREATE FUNCTION pgtle.install_extension
+(
+  name text,
+  version text,
+  description text,
+  ext text,
+  requires text[] DEFAULT NULL,
+  schema text DEFAULT NULL
+)
+RETURNS boolean
+SET search_path TO 'pgtle'
+AS 'MODULE_PATHNAME', 'pg_tle_install_extension'
+LANGUAGE C;

--- a/pg_tle--1.4.1--1.5.0.sql
+++ b/pg_tle--1.4.1--1.5.0.sql
@@ -25,6 +25,7 @@ DROP FUNCTION pgtle.install_extension
   ext text,
   requires text[]
 );
+
 CREATE FUNCTION pgtle.install_extension
 (
   name text,
@@ -38,3 +39,23 @@ RETURNS boolean
 SET search_path TO 'pgtle'
 AS 'MODULE_PATHNAME', 'pg_tle_install_extension'
 LANGUAGE C;
+
+REVOKE EXECUTE ON FUNCTION pgtle.install_extension
+(
+  name text,
+  version text,
+  description text,
+  ext text,
+  requires text[],
+  schema text
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION pgtle.install_extension
+(
+  name text,
+  version text,
+  description text,
+  ext text,
+  requires text[],
+  schema text
+) TO pgtle_admin;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4421,7 +4421,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	Oid			ctlfuncid;
 	Oid			sqlfuncid;
 
-	if (PG_ARGISNULL(0))
+	if (PG_ARGISNULL(0) || !PG_GETARG_DATUM(0))
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("\"name\" is a required argument")));
@@ -4440,7 +4440,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 				 errmsg("control file already exists for the %s extension",
 						extname)));
 
-	if (PG_ARGISNULL(1))
+	if (PG_ARGISNULL(1) || !PG_GETARG_DATUM(1))
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("\"version\" is a required argument")));
@@ -4448,21 +4448,21 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	extvers = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	check_valid_version_name(extvers);
 
-	if (PG_ARGISNULL(2))
+	if (PG_ARGISNULL(2) || !PG_GETARG_DATUM(2))
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("\"description\" is a required argument")));
 
 	extdesc = text_to_cstring(PG_GETARG_TEXT_PP(2));
 
-	if (PG_ARGISNULL(3))
+	if (PG_ARGISNULL(3) || !PG_GETARG_DATUM(3))
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("\"ext\" is a required argument")));
 
 	sql_str = text_to_cstring(PG_GETARG_TEXT_PP(3));
 
-	if (PG_ARGISNULL(4))
+	if (PG_ARGISNULL(4) || !PG_GETARG_DATUM(4))
 		reqlist = NIL;
 	else
 	{
@@ -4471,7 +4471,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 		check_requires_list(reqlist);
 	}
 
-	if (PG_ARGISNULL(5))
+	if (PG_ARGISNULL(5) || !PG_GETARG_DATUM(5))
 		extschema = NULL;
 	else
 	{

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -914,7 +914,6 @@ parse_extension_control_file(ExtensionControlFile *control,
 		control->directory = NULL;
 		control->module_pathname = NULL;
 		control->relocatable = false;
-		control->schema = NULL;
 		control->superuser = false;
 		control->trusted = false;
 		control->encoding = -1; /* encoding is that of the server_side

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2524,8 +2524,8 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 		{
 			ExtensionControlFile *control;
 			char	   *extname;
-			Datum		values[3];
-			bool		nulls[3];
+			Datum		values[4];
+			bool		nulls[4];
 			char	   *fname = SPI_getvalue(SPI_tuptable->vals[i],
 											 SPI_tuptable->tupdesc, 1);
 
@@ -2558,6 +2558,11 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 				nulls[2] = true;
 			else
 				values[2] = CStringGetTextDatum(control->comment);
+			/* schema */
+			if (control->schema == NULL)
+				nulls[3] = true;
+			else
+				values[3] = CStringGetTextDatum(control->schema);
 
 			tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc,
 								 values, nulls);

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -999,6 +999,12 @@ build_extension_control_file_string(ExtensionControlFile *control)
 						 quote_literal_cstr(reqstr->data));
 	}
 
+	if (control->schema != NULL)
+	{
+		appendStringInfo(ctlstr, "schema = %s\n",
+						quote_literal_cstr(control->schema));
+	}
+
 	return ctlstr;
 }
 
@@ -4398,6 +4404,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	char	   *extdesc;
 	char	   *sql_str;
 	ArrayType  *extrequires;
+	char       *extschema;
 	char	   *ctlname;
 	StringInfo	ctlstr;
 	char	   *sqlname;
@@ -4465,6 +4472,11 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 		check_requires_list(reqlist);
 	}
 
+	if (!PG_ARGISNULL(5))
+	{
+		extschema = text_to_cstring(PG_GETARG_TEXT_PP(5));
+	}
+
 	/*
 	 * Build appropriate function names based on extension name and version.
 	 */
@@ -4504,6 +4516,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	control->default_version = pstrdup(extvers);
 	control->comment = pstrdup(extdesc);
 	control->requires = reqlist;
+	control->schema = pstrdup(extschema);
 
 	ctlstr = build_extension_control_file_string(control);
 

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2562,7 +2562,8 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 			if (control->schema == NULL)
 				nulls[3] = true;
 			else
-				values[3] = CStringGetTextDatum(control->schema);
+				values[3] = DirectFunctionCall1(namein,
+											    CStringGetDatum(control->schema));
 
 			tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc,
 								 values, nulls);

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -2524,8 +2524,8 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 		{
 			ExtensionControlFile *control;
 			char	   *extname;
-			Datum		values[4];
-			bool		nulls[4];
+			Datum		values[3];
+			bool		nulls[3];
 			char	   *fname = SPI_getvalue(SPI_tuptable->vals[i],
 											 SPI_tuptable->tupdesc, 1);
 
@@ -2558,12 +2558,6 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 				nulls[2] = true;
 			else
 				values[2] = CStringGetTextDatum(control->comment);
-			/* schema */
-			if (control->schema == NULL)
-				nulls[3] = true;
-			else
-				values[3] = DirectFunctionCall1(namein,
-												CStringGetDatum(control->schema));
 
 			tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc,
 								 values, nulls);

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1001,7 +1001,7 @@ build_extension_control_file_string(ExtensionControlFile *control)
 	if (control->schema != NULL)
 	{
 		appendStringInfo(ctlstr, "schema = %s\n",
-						quote_literal_cstr(control->schema));
+						 quote_literal_cstr(control->schema));
 	}
 
 	return ctlstr;
@@ -2563,7 +2563,7 @@ pg_tle_available_extensions(PG_FUNCTION_ARGS)
 				nulls[3] = true;
 			else
 				values[3] = DirectFunctionCall1(namein,
-											    CStringGetDatum(control->schema));
+												CStringGetDatum(control->schema));
 
 			tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc,
 								 values, nulls);
@@ -4409,7 +4409,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	char	   *extdesc;
 	char	   *sql_str;
 	ArrayType  *extrequires;
-	char       *extschema;
+	char	   *extschema;
 	char	   *ctlname;
 	StringInfo	ctlstr;
 	char	   *sqlname;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -4472,9 +4472,11 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 		check_requires_list(reqlist);
 	}
 
-	if (!PG_ARGISNULL(5))
+	if (PG_ARGISNULL(5))
+		extschema = NULL;
+	else
 	{
-		extschema = text_to_cstring(PG_GETARG_TEXT_PP(5));
+		extschema = pstrdup(text_to_cstring(PG_GETARG_TEXT_PP(5)));
 	}
 
 	/*
@@ -4516,7 +4518,7 @@ pg_tle_install_extension(PG_FUNCTION_ARGS)
 	control->default_version = pstrdup(extvers);
 	control->comment = pstrdup(extdesc);
 	control->requires = reqlist;
-	control->schema = pstrdup(extschema);
+	control->schema = extschema;
 
 	ctlstr = build_extension_control_file_string(control);
 

--- a/test/expected/pg_tle_api_clusterwide.out
+++ b/test/expected/pg_tle_api_clusterwide.out
@@ -370,3 +370,12 @@ SELECT pgtle.uninstall_extension('test_unregister_feature');
 DROP SCHEMA pass CASCADE;
 NOTICE:  drop cascades to function pass.password_check_length_greater_than_8(text,text,pgtle.password_types,timestamp with time zone,boolean)
 DROP EXTENSION pg_tle;
+ALTER SYSTEM SET pgtle.passcheck_db_name = '';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- reconnect to ensure reload settings are propagated immediately
+\c -

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -70,14 +70,6 @@ SELECT my_tle_schema_1.my_tle_func();
            1
 (1 row)
 
--- By specifying the columns explicitly, we can get the same output from
--- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
-SELECT name, default_version, comment FROM pgtle.available_extensions();
-  name  | default_version | comment 
---------+-----------------+---------
- my_tle | 1.0             | My TLE
-(1 row)
-
 -- Clean up.
 DROP EXTENSION my_tle CASCADE;
 SELECT pgtle.uninstall_extension('my_tle');

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -255,21 +255,21 @@ SELECT * from pgtle.available_extension_versions();
  plpgsql  | 1.0     | pg_catalog      | PL/pgSQL procedural language
 (6 rows)
 
--- Clean up.
+-- Clean up. Drop the SQL and control functions explicitly to make sure the
+-- drops happen in the expected order and avoid random errors.
+DROP FUNCTION pgtle."my_tle_4--1.0.sql" CASCADE;
+NOTICE:  drop cascades to extension my_tle_4
+DROP FUNCTION pgtle."my_tle_4.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_3--1.0.sql" CASCADE;
+NOTICE:  drop cascades to extension my_tle_3
+DROP FUNCTION pgtle."my_tle_3.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_2--1.0.sql" CASCADE;
+NOTICE:  drop cascades to extension my_tle_2
+DROP FUNCTION pgtle."my_tle_2.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_1--1.0.sql" CASCADE;
+NOTICE:  drop cascades to extension my_tle_1
+DROP FUNCTION pgtle."my_tle_1.control" CASCADE;
 DROP EXTENSION pg_tle CASCADE;
-NOTICE:  drop cascades to 12 other objects
-DETAIL:  drop cascades to function pgtle."my_tle_1--1.0.sql"()
-drop cascades to function pgtle."my_tle_1.control"()
-drop cascades to function pgtle."my_tle_2--1.0.sql"()
-drop cascades to function pgtle."my_tle_2.control"()
-drop cascades to function pgtle."my_tle_3--1.0.sql"()
-drop cascades to function pgtle."my_tle_3.control"()
-drop cascades to function pgtle."my_tle_4--1.0.sql"()
-drop cascades to function pgtle."my_tle_4.control"()
-drop cascades to extension my_tle_1
-drop cascades to extension my_tle_2
-drop cascades to extension my_tle_3
-drop cascades to extension my_tle_4
 DROP SCHEMA pgtle;
 DROP SCHEMA my_tle_schema_1;
 DROP SCHEMA my_tle_schema_2;

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -1,0 +1,266 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * 1. If an extension is created on pg_tle 1.4.1 and pg_tle is upgraded to
+ *    1.5.0, the extension behaves like a regular schema-less extension.
+ *
+ * 2. If an extension is installed with a specified schema, it cannot be created
+ *    in a different schema.
+ *
+ * 3. If an extension is installed with a specified schema, it cannot be created
+ *    if the schema does not exist.
+ *
+ * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
+ *    print the correct output for a variety of extensions.
+ */
+\pset pager off
+/*
+ * 1. If an extension is installed on pg_tle 1.4.1 and pg_tle is upgraded to
+ *    1.5.0, the extension behaves like a regular schema-less extension.
+ */
+CREATE SCHEMA my_tle_schema_1;
+CREATE SCHEMA my_tle_schema_2;
+CREATE EXTENSION pg_tle VERSION '1.4.1';
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT * FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
+(1 row)
+
+-- Extension is relocatable during CREATE, but not after.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
+ERROR:  extension "my_tle" does not support SET SCHEMA
+SELECT my_tle_schema_1.my_tle_func();
+ my_tle_func 
+-------------
+           1
+(1 row)
+
+DROP EXTENSION my_tle CASCADE;
+-- Upgrade pg_tle to 1.5.0 and repeat the test.
+ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
+ERROR:  extension "my_tle" does not support SET SCHEMA
+SELECT my_tle_schema_1.my_tle_func();
+ my_tle_func 
+-------------
+           1
+(1 row)
+
+-- Clean up.
+DROP EXTENSION my_tle CASCADE;
+SELECT pgtle.uninstall_extension('my_tle');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;
+/*
+ * 2. If an extension is installed with a specified schema, it cannot be created
+ *    in a different schema. The extension objects are automatically created in
+ *    the specified schema.
+ */
+CREATE SCHEMA my_tle_schema_1;
+CREATE SCHEMA my_tle_schema_2;
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT * FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
+(1 row)
+
+-- my_tle cannot be installed in my_tle_schema_2.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_2;
+ERROR:  extension "my_tle" must be installed in schema "my_tle_schema_1"
+-- my_tle_func is automatically created in my_tle_schema_1.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+SELECT my_tle_schema_1.my_tle_func();
+ my_tle_func 
+-------------
+           1
+(1 row)
+
+-- Clean up.
+DROP EXTENSION my_tle CASCADE;
+SELECT pgtle.uninstall_extension('my_tle');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;
+/*
+ * 3. If an extension is installed with a specified schema, the schema is
+ *    automatically created when the extension is created.
+ */
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT * FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
+(1 row)
+
+CREATE EXTENSION my_tle;
+SELECT my_tle_schema_1.my_tle_func();
+ my_tle_func 
+-------------
+           1
+(1 row)
+
+-- Cannot drop the schema because the extension depends on it.
+DROP SCHEMA my_tle_schema_1;
+ERROR:  cannot drop schema my_tle_schema_1 because other objects depend on it
+DETAIL:  extension my_tle depends on schema my_tle_schema_1
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+-- Clean up.
+DROP SCHEMA my_tle_schema_1 CASCADE;
+NOTICE:  drop cascades to extension my_tle
+-- my_tle is dropped automatically, so this line throws an error.
+DROP EXTENSION my_tle;
+ERROR:  extension "my_tle" does not exist
+SELECT pgtle.uninstall_extension('my_tle');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+/*
+ * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
+ *    print the correct output for a variety of extensions.
+ */
+-- Install four extensions with all combinations of null/non-null requires and
+-- null/non-null schema.
+SELECT pgtle.install_extension('my_tle_1', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_1() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_extension('my_tle_2', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_2() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{my_tle_1}');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_extension('my_tle_3', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_3() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+SELECT pgtle.install_extension('my_tle_4', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_4() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{my_tle_3}', 'my_tle_schema_2');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+-- Create all the extensions.
+CREATE EXTENSION my_tle_1;
+CREATE EXTENSION my_tle_2;
+CREATE EXTENSION my_tle_3;
+CREATE EXTENSION my_tle_4;
+-- Validate the output of these functions.
+SELECT * from pgtle.available_extensions();
+   name   | default_version | comment 
+----------+-----------------+---------
+ my_tle_1 | 1.0             | My TLE
+ my_tle_2 | 1.0             | My TLE
+ my_tle_3 | 1.0             | My TLE
+ my_tle_4 | 1.0             | My TLE
+(4 rows)
+
+SELECT * from pgtle.available_extension_versions();
+   name   | version | superuser | trusted | relocatable |     schema      |     requires      | comment 
+----------+---------+-----------+---------+-------------+-----------------+-------------------+---------
+ my_tle_1 | 1.0     | f         | f       | f           |                 | {pg_tle}          | My TLE
+ my_tle_2 | 1.0     | f         | f       | f           |                 | {my_tle_1,pg_tle} | My TLE
+ my_tle_3 | 1.0     | f         | f       | f           | my_tle_schema_1 | {pg_tle}          | My TLE
+ my_tle_4 | 1.0     | f         | f       | f           | my_tle_schema_2 | {my_tle_3,pg_tle} | My TLE
+(4 rows)
+
+\dx
+                           List of installed extensions
+   Name   | Version |     Schema      |                Description                 
+----------+---------+-----------------+--------------------------------------------
+ my_tle_1 | 1.0     | public          | My TLE
+ my_tle_2 | 1.0     | public          | My TLE
+ my_tle_3 | 1.0     | my_tle_schema_1 | My TLE
+ my_tle_4 | 1.0     | my_tle_schema_2 | My TLE
+ pg_tle   | 1.5.0   | pgtle           | Trusted Language Extensions for PostgreSQL
+ plpgsql  | 1.0     | pg_catalog      | PL/pgSQL procedural language
+(6 rows)
+
+-- Clean up.
+DROP EXTENSION pg_tle CASCADE;
+NOTICE:  drop cascades to 12 other objects
+DETAIL:  drop cascades to function pgtle."my_tle_1--1.0.sql"()
+drop cascades to function pgtle."my_tle_1.control"()
+drop cascades to function pgtle."my_tle_2--1.0.sql"()
+drop cascades to function pgtle."my_tle_2.control"()
+drop cascades to function pgtle."my_tle_3--1.0.sql"()
+drop cascades to function pgtle."my_tle_3.control"()
+drop cascades to function pgtle."my_tle_4--1.0.sql"()
+drop cascades to function pgtle."my_tle_4.control"()
+drop cascades to extension my_tle_1
+drop cascades to extension my_tle_2
+drop cascades to extension my_tle_3
+drop cascades to extension my_tle_4
+DROP SCHEMA pgtle;
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -36,7 +36,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
  t
 (1 row)
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
   name  | default_version | comment 
 --------+-----------------+---------
  my_tle | 1.0             | My TLE
@@ -55,7 +55,7 @@ SELECT my_tle_schema_1.my_tle_func();
 DROP EXTENSION my_tle CASCADE;
 -- Upgrade pg_tle to 1.5.0 and repeat the test.
 ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
   name  | default_version | comment 
 --------+-----------------+---------
  my_tle | 1.0             | My TLE
@@ -98,7 +98,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
  t
 (1 row)
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
   name  | default_version | comment 
 --------+-----------------+---------
  my_tle | 1.0             | My TLE
@@ -140,7 +140,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
  t
 (1 row)
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
   name  | default_version | comment 
 --------+-----------------+---------
  my_tle | 1.0             | My TLE
@@ -225,7 +225,7 @@ CREATE EXTENSION my_tle_2;
 CREATE EXTENSION my_tle_3;
 CREATE EXTENSION my_tle_4;
 -- Validate the output of these functions.
-SELECT * from pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
    name   | default_version | comment 
 ----------+-----------------+---------
  my_tle_1 | 1.0             | My TLE
@@ -234,7 +234,7 @@ SELECT * from pgtle.available_extensions();
  my_tle_4 | 1.0             | My TLE
 (4 rows)
 
-SELECT * from pgtle.available_extension_versions();
+SELECT * from pgtle.available_extension_versions() ORDER BY name;
    name   | version | superuser | trusted | relocatable |     schema      |     requires      | comment 
 ----------+---------+-----------+---------+-------------+-----------------+-------------------+---------
  my_tle_1 | 1.0     | f         | f       | f           |                 | {pg_tle}          | My TLE

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -5,12 +5,14 @@
 /*
  * 1. If an extension is created on pg_tle 1.4.1 and pg_tle is upgraded to
  *    1.5.0, the extension behaves like a regular schema-less extension.
+ *    pgtle.available_extensions() works on both 1.4.1 and 1.5.0.
  *
  * 2. If an extension is installed with a specified schema, it cannot be created
- *    in a different schema.
+ *    in a different schema. The extension objects are automatically created in
+ *    the specified schema.
  *
- * 3. If an extension is installed with a specified schema, it cannot be created
- *    if the schema does not exist.
+ * 3. If an extension is installed with a specified schema, the schema is
+ *    automatically created when the extension is created.
  *
  * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
  *    print the correct output for a variety of extensions.
@@ -19,6 +21,7 @@
 /*
  * 1. If an extension is installed on pg_tle 1.4.1 and pg_tle is upgraded to
  *    1.5.0, the extension behaves like a regular schema-less extension.
+ *    pgtle.available_extensions() works on both 1.4.1 and 1.5.0.
  */
 CREATE SCHEMA my_tle_schema_1;
 CREATE SCHEMA my_tle_schema_2;
@@ -52,6 +55,12 @@ SELECT my_tle_schema_1.my_tle_func();
 DROP EXTENSION my_tle CASCADE;
 -- Upgrade pg_tle to 1.5.0 and repeat the test.
 ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
+SELECT * FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
+(1 row)
+
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
 ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
 ERROR:  extension "my_tle" does not support SET SCHEMA
@@ -59,6 +68,14 @@ SELECT my_tle_schema_1.my_tle_func();
  my_tle_func 
 -------------
            1
+(1 row)
+
+-- By specifying the columns explicitly, we can get the same output from
+-- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
+SELECT name, default_version, comment FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
 (1 row)
 
 -- Clean up.

--- a/test/expected/pg_tle_functions_acl.out
+++ b/test/expected/pg_tle_functions_acl.out
@@ -16,6 +16,12 @@
  */
 -- Set up.
 CREATE EXTENSION pg_tle;
+SELECT pgtle.install_extension('test_ext', '1.0', '', '');
+ install_extension 
+-------------------
+ t
+(1 row)
+
 CREATE USER acl_user;
 GRANT CREATE ON SCHEMA public TO acl_user;
 SET SESSION AUTHORIZATION acl_user;
@@ -36,19 +42,22 @@ $$;
  */
 -- Unprivileged user can execute these functions.
 SELECT pgtle.available_extension_versions();
- available_extension_versions 
-------------------------------
-(0 rows)
+   available_extension_versions    
+-----------------------------------
+ (test_ext,1.0,f,f,f,,{pg_tle},"")
+(1 row)
 
 SELECT pgtle.available_extensions();
  available_extensions 
 ----------------------
+ (test_ext,1.0,"")
+(1 row)
+
+SELECT pgtle.extension_update_paths('test_ext');
+ extension_update_paths 
+------------------------
 (0 rows)
 
-SELECT pgtle.extension_update_paths('imaginary_extension');
-ERROR:  extension "imaginary_extension" is not available
-DETAIL:  Could not find extension control function "imaginary_extension.control": No such file or directory.
-HINT:  The extension must first be installed in the current database.
 -- Unprivileged user cannot execute these functions.
 SELECT pgtle.create_base_type('public', 'imaginary_type',
     'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
@@ -100,19 +109,22 @@ GRANT pgtle_admin TO acl_user;
 SET SESSION AUTHORIZATION acl_user;
 -- pgtle_admin can execute all functions.
 SELECT pgtle.available_extension_versions();
- available_extension_versions 
-------------------------------
-(0 rows)
+   available_extension_versions    
+-----------------------------------
+ (test_ext,1.0,f,f,f,,{pg_tle},"")
+(1 row)
 
 SELECT pgtle.available_extensions();
  available_extensions 
 ----------------------
+ (test_ext,1.0,"")
+(1 row)
+
+SELECT pgtle.extension_update_paths('test_ext');
+ extension_update_paths 
+------------------------
 (0 rows)
 
-SELECT pgtle.extension_update_paths('imaginary_extension');
-ERROR:  extension "imaginary_extension" is not available
-DETAIL:  Could not find extension control function "imaginary_extension.control": Resource temporarily unavailable.
-HINT:  The extension must first be installed in the current database.
 SELECT pgtle.create_base_type('public', 'imaginary_type',
     'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
 ERROR:  type "imaginary_type" does not exist
@@ -169,17 +181,18 @@ SELECT pgtle.set_default_version('', '');
 ERROR:  invalid extension name: ""
 DETAIL:  Extension names must not be empty.
 SELECT pgtle.uninstall_extension('');
-ERROR:  Extension  does not exist
-CONTEXT:  PL/pgSQL function uninstall_extension(text) line 18 at RAISE
+ERROR:  must be owner of function test_ext.control
+CONTEXT:  SQL statement "DROP FUNCTION "test_ext.control"()"
+PL/pgSQL function uninstall_extension(text) line 22 at EXECUTE
 SELECT pgtle.uninstall_extension('', '');
 ERROR:  Version  of extension  is not installed and therefore can not be uninstalled
 CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 50 at RAISE
 SELECT pgtle.uninstall_extension_if_exists('');
- uninstall_extension_if_exists 
--------------------------------
- f
-(1 row)
-
+ERROR:  must be owner of function test_ext.control
+CONTEXT:  SQL statement "DROP FUNCTION "test_ext.control"()"
+PL/pgSQL function uninstall_extension(text) line 22 at EXECUTE
+SQL statement "SELECT pgtle.uninstall_extension(extname)"
+PL/pgSQL function uninstall_extension_if_exists(text) line 3 at PERFORM
 SELECT pgtle.uninstall_update_path('', '', '');
 ERROR:  Extension  does not exist
 CONTEXT:  PL/pgSQL function uninstall_update_path(text,text,text) line 16 at RAISE
@@ -209,6 +222,12 @@ DROP FUNCTION op;
 DROP TYPE imaginary_type;
 RESET SESSION AUTHORIZATION;
 REVOKE CREATE ON SCHEMA public FROM acl_user;
+SELECT pgtle.uninstall_extension('test_ext');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
 DROP EXTENSION pg_tle CASCADE;
 DROP SCHEMA pgtle;
 DROP USER acl_user;

--- a/test/expected/pg_tle_functions_acl.out
+++ b/test/expected/pg_tle_functions_acl.out
@@ -1,0 +1,214 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * 1) Verify that an unprivileged user has the expected EXECUTE permissions on
+ * each pg_tle function.  All new SQL functions should be added to this test.
+ *
+ * If the function is not executable by the unprivileged user, we expect the
+ * exact error "permission denied for function <function_name>".  If a different
+ * error is thrown (except for syntax errors), that means the unprivileged user
+ * has EXECUTE permission.
+ * 
+ * 2) Verify that a pgtle_admin user has EXECUTE permission on each pg_tle
+ * function.
+ */
+-- Set up.
+CREATE EXTENSION pg_tle;
+CREATE USER acl_user;
+GRANT CREATE ON SCHEMA public TO acl_user;
+SET SESSION AUTHORIZATION acl_user;
+CREATE FUNCTION datin(t text) RETURNS bytea LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT pg_catalog.convert_to(t, 'UTF8');
+$$;
+CREATE FUNCTION datout(b bytea) RETURNS text LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT pg_catalog.convert_from(b, 'UTF8');
+$$;
+CREATE FUNCTION op(b bytea) RETURNS boolean LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT false;
+$$;
+/*
+ * 1. Test unprivileged user permissions.
+ */
+-- Unprivileged user can execute these functions.
+SELECT pgtle.available_extension_versions();
+ available_extension_versions 
+------------------------------
+(0 rows)
+
+SELECT pgtle.available_extensions();
+ available_extensions 
+----------------------
+(0 rows)
+
+SELECT pgtle.extension_update_paths('imaginary_extension');
+ERROR:  extension "imaginary_extension" is not available
+DETAIL:  Could not find extension control function "imaginary_extension.control": No such file or directory.
+HINT:  The extension must first be installed in the current database.
+-- Unprivileged user cannot execute these functions.
+SELECT pgtle.create_base_type('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+ERROR:  permission denied for function create_base_type
+SELECT pgtle.create_base_type_if_not_exists('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+ERROR:  permission denied for function create_base_type_if_not_exists
+SELECT pgtle.create_operator_func('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+ERROR:  permission denied for function create_operator_func
+SELECT pgtle.create_operator_func_if_not_exists('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+ERROR:  permission denied for function create_operator_func_if_not_exists
+SELECT pgtle.create_shell_type('public', 'imaginary_type');
+ERROR:  permission denied for function create_shell_type
+SELECT pgtle.create_shell_type_if_not_exists('public', 'imaginary_type');
+ERROR:  permission denied for function create_shell_type_if_not_exists
+SELECT pgtle.install_extension('', '', '', '');
+ERROR:  permission denied for function install_extension
+SELECT pgtle.install_extension_version_sql('', '', '');
+ERROR:  permission denied for function install_extension_version_sql
+SELECT pgtle.register_feature('op(bytea)'::regprocedure, 'passcheck');
+ERROR:  permission denied for function register_feature
+SELECT pgtle.register_feature_if_not_exists('op(bytea)'::regprocedure,
+    'passcheck');
+ERROR:  permission denied for function register_feature_if_not_exists
+SELECT pgtle.set_default_version('', '');
+ERROR:  permission denied for function set_default_version
+SELECT pgtle.uninstall_extension('');
+ERROR:  permission denied for function uninstall_extension
+SELECT pgtle.uninstall_extension('', '');
+ERROR:  permission denied for function uninstall_extension
+SELECT pgtle.uninstall_extension_if_exists('');
+ERROR:  permission denied for function uninstall_extension_if_exists
+SELECT pgtle.uninstall_update_path('', '', '');
+ERROR:  permission denied for function uninstall_update_path
+SELECT pgtle.uninstall_update_path_if_exists('', '', '');
+ERROR:  permission denied for function uninstall_update_path_if_exists
+SELECT pgtle.unregister_feature('op(bytea)'::regprocedure, 'passcheck');
+ERROR:  permission denied for function unregister_feature
+SELECT pgtle.unregister_feature_if_exists('op(bytea)'::regprocedure,
+    'passcheck');
+ERROR:  permission denied for function unregister_feature_if_exists
+/*
+ * 2. Test pgtle_admin user permissions.
+ */
+RESET SESSION AUTHORIZATION;
+GRANT pgtle_admin TO acl_user;
+SET SESSION AUTHORIZATION acl_user;
+-- pgtle_admin can execute all functions.
+SELECT pgtle.available_extension_versions();
+ available_extension_versions 
+------------------------------
+(0 rows)
+
+SELECT pgtle.available_extensions();
+ available_extensions 
+----------------------
+(0 rows)
+
+SELECT pgtle.extension_update_paths('imaginary_extension');
+ERROR:  extension "imaginary_extension" is not available
+DETAIL:  Could not find extension control function "imaginary_extension.control": Resource temporarily unavailable.
+HINT:  The extension must first be installed in the current database.
+SELECT pgtle.create_base_type('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+ERROR:  type "imaginary_type" does not exist
+HINT:  Create the type as a shell type, then create its I/O functions, then do a full CREATE TYPE.
+SELECT pgtle.create_base_type_if_not_exists('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+ERROR:  type "imaginary_type" does not exist
+HINT:  Create the type as a shell type, then create its I/O functions, then do a full CREATE TYPE.
+CONTEXT:  SQL statement "SELECT pgtle.create_base_type(typenamespace, typename, infunc, outfunc, internallength, alignment, storage)"
+PL/pgSQL function create_base_type_if_not_exists(regnamespace,name,regprocedure,regprocedure,integer,text,text) line 3 at PERFORM
+SELECT pgtle.create_operator_func('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+ERROR:  type "imaginary_type" does not exist
+SELECT pgtle.create_operator_func_if_not_exists('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+ERROR:  type "imaginary_type" does not exist
+CONTEXT:  SQL statement "SELECT pgtle.create_operator_func(typenamespace, typename, opfunc)"
+PL/pgSQL function create_operator_func_if_not_exists(regnamespace,name,regprocedure) line 3 at PERFORM
+SELECT pgtle.create_shell_type('public', 'imaginary_type');
+ create_shell_type 
+-------------------
+ 
+(1 row)
+
+SELECT pgtle.create_shell_type_if_not_exists('public', 'imaginary_type');
+NOTICE:  type "imaginary_type" already exists, skipping
+ create_shell_type_if_not_exists 
+---------------------------------
+ f
+(1 row)
+
+SELECT pgtle.install_extension('', '', '', '');
+ERROR:  invalid extension name: ""
+DETAIL:  Extension names must not be empty.
+SELECT pgtle.install_extension_version_sql('', '', '');
+ERROR:  invalid extension name: ""
+DETAIL:  Extension names must not be empty.
+SELECT pgtle.register_feature('op(bytea)'::regprocedure, 'passcheck');
+NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+ register_feature 
+------------------
+ 
+(1 row)
+
+SELECT pgtle.register_feature_if_not_exists('op(bytea)'::regprocedure,
+    'passcheck');
+NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+ register_feature_if_not_exists 
+--------------------------------
+ f
+(1 row)
+
+SELECT pgtle.set_default_version('', '');
+ERROR:  invalid extension name: ""
+DETAIL:  Extension names must not be empty.
+SELECT pgtle.uninstall_extension('');
+ERROR:  Extension  does not exist
+CONTEXT:  PL/pgSQL function uninstall_extension(text) line 18 at RAISE
+SELECT pgtle.uninstall_extension('', '');
+ERROR:  Version  of extension  is not installed and therefore can not be uninstalled
+CONTEXT:  PL/pgSQL function uninstall_extension(text,text) line 50 at RAISE
+SELECT pgtle.uninstall_extension_if_exists('');
+ uninstall_extension_if_exists 
+-------------------------------
+ f
+(1 row)
+
+SELECT pgtle.uninstall_update_path('', '', '');
+ERROR:  Extension  does not exist
+CONTEXT:  PL/pgSQL function uninstall_update_path(text,text,text) line 16 at RAISE
+SELECT pgtle.uninstall_update_path_if_exists('', '', '');
+ uninstall_update_path_if_exists 
+---------------------------------
+ f
+(1 row)
+
+SELECT pgtle.unregister_feature('op(bytea)'::regprocedure, 'passcheck');
+ unregister_feature 
+--------------------
+ 
+(1 row)
+
+SELECT pgtle.unregister_feature_if_exists('op(bytea)'::regprocedure,
+    'passcheck');
+ unregister_feature_if_exists 
+------------------------------
+ f
+(1 row)
+
+-- Clean up.
+DROP FUNCTION datin;
+DROP FUNCTION datout;
+DROP FUNCTION op;
+DROP TYPE imaginary_type;
+RESET SESSION AUTHORIZATION;
+REVOKE CREATE ON SCHEMA public FROM acl_user;
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP USER acl_user;

--- a/test/sql/pg_tle_api_clusterwide.sql
+++ b/test/sql/pg_tle_api_clusterwide.sql
@@ -243,3 +243,7 @@ SELECT pgtle.uninstall_extension('test_unregister_feature');
 -- now drop everything
 DROP SCHEMA pass CASCADE;
 DROP EXTENSION pg_tle;
+ALTER SYSTEM SET pgtle.passcheck_db_name = '';
+SELECT pg_reload_conf();
+-- reconnect to ensure reload settings are propagated immediately
+\c -

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -154,7 +154,16 @@ SELECT * from pgtle.available_extensions();
 SELECT * from pgtle.available_extension_versions();
 \dx
 
--- Clean up.
+-- Clean up. Drop the SQL and control functions explicitly to make sure the
+-- drops happen in the expected order and avoid random errors.
+DROP FUNCTION pgtle."my_tle_4--1.0.sql" CASCADE;
+DROP FUNCTION pgtle."my_tle_4.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_3--1.0.sql" CASCADE;
+DROP FUNCTION pgtle."my_tle_3.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_2--1.0.sql" CASCADE;
+DROP FUNCTION pgtle."my_tle_2.control" CASCADE;
+DROP FUNCTION pgtle."my_tle_1--1.0.sql" CASCADE;
+DROP FUNCTION pgtle."my_tle_1.control" CASCADE;
 DROP EXTENSION pg_tle CASCADE;
 DROP SCHEMA pgtle;
 DROP SCHEMA my_tle_schema_1;

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -51,10 +51,6 @@ CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
 ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
 SELECT my_tle_schema_1.my_tle_func();
 
--- By specifying the columns explicitly, we can get the same output from
--- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
-SELECT name, default_version, comment FROM pgtle.available_extensions();
-
 -- Clean up.
 DROP EXTENSION my_tle CASCADE;
 SELECT pgtle.uninstall_extension('my_tle');

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -36,7 +36,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
             'SELECT 1';
     $_pgtle_$);
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
 
 -- Extension is relocatable during CREATE, but not after.
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
@@ -46,7 +46,7 @@ DROP EXTENSION my_tle CASCADE;
 
 -- Upgrade pg_tle to 1.5.0 and repeat the test.
 ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
 ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
 SELECT my_tle_schema_1.my_tle_func();
@@ -72,7 +72,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
     $_pgtle_$,
     '{}', 'my_tle_schema_1');
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
 
 -- my_tle cannot be installed in my_tle_schema_2.
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_2;
@@ -98,7 +98,7 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
     $_pgtle_$,
     '{}', 'my_tle_schema_1');
 
-SELECT * FROM pgtle.available_extensions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
 
 CREATE EXTENSION my_tle;
 SELECT my_tle_schema_1.my_tle_func();
@@ -150,8 +150,8 @@ CREATE EXTENSION my_tle_3;
 CREATE EXTENSION my_tle_4;
 
 -- Validate the output of these functions.
-SELECT * from pgtle.available_extensions();
-SELECT * from pgtle.available_extension_versions();
+SELECT * FROM pgtle.available_extensions() ORDER BY name;
+SELECT * from pgtle.available_extension_versions() ORDER BY name;
 \dx
 
 -- Clean up. Drop the SQL and control functions explicitly to make sure the

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * 1. If an extension is created on pg_tle 1.4.1 and pg_tle is upgraded to
+ *    1.5.0, the extension behaves like a regular schema-less extension.
+ *
+ * 2. If an extension is installed with a specified schema, it cannot be created
+ *    in a different schema.
+ *
+ * 3. If an extension is installed with a specified schema, it cannot be created
+ *    if the schema does not exist.
+ *
+ * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
+ *    print the correct output for a variety of extensions.
+ */
+
+\pset pager off
+
+/*
+ * 1. If an extension is installed on pg_tle 1.4.1 and pg_tle is upgraded to
+ *    1.5.0, the extension behaves like a regular schema-less extension.
+ */
+
+CREATE SCHEMA my_tle_schema_1;
+CREATE SCHEMA my_tle_schema_2;
+CREATE EXTENSION pg_tle VERSION '1.4.1';
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$);
+
+SELECT * FROM pgtle.available_extensions();
+
+-- Extension is relocatable during CREATE, but not after.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
+SELECT my_tle_schema_1.my_tle_func();
+DROP EXTENSION my_tle CASCADE;
+
+-- Upgrade pg_tle to 1.5.0 and repeat the test.
+ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
+SELECT my_tle_schema_1.my_tle_func();
+
+-- Clean up.
+DROP EXTENSION my_tle CASCADE;
+SELECT pgtle.uninstall_extension('my_tle');
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;
+
+/*
+ * 2. If an extension is installed with a specified schema, it cannot be created
+ *    in a different schema. The extension objects are automatically created in
+ *    the specified schema.
+ */
+
+CREATE SCHEMA my_tle_schema_1;
+CREATE SCHEMA my_tle_schema_2;
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+
+SELECT * FROM pgtle.available_extensions();
+
+-- my_tle cannot be installed in my_tle_schema_2.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_2;
+-- my_tle_func is automatically created in my_tle_schema_1.
+CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
+SELECT my_tle_schema_1.my_tle_func();
+
+-- Clean up.
+DROP EXTENSION my_tle CASCADE;
+SELECT pgtle.uninstall_extension('my_tle');
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;
+
+/*
+ * 3. If an extension is installed with a specified schema, the schema is
+ *    automatically created when the extension is created.
+ */
+
+SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+
+SELECT * FROM pgtle.available_extensions();
+
+CREATE EXTENSION my_tle;
+SELECT my_tle_schema_1.my_tle_func();
+
+-- Cannot drop the schema because the extension depends on it.
+DROP SCHEMA my_tle_schema_1;
+
+-- Clean up.
+DROP SCHEMA my_tle_schema_1 CASCADE;
+-- my_tle is dropped automatically, so this line throws an error.
+DROP EXTENSION my_tle;
+SELECT pgtle.uninstall_extension('my_tle');
+
+/*
+ * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
+ *    print the correct output for a variety of extensions.
+ */
+
+-- Install four extensions with all combinations of null/non-null requires and
+-- null/non-null schema.
+SELECT pgtle.install_extension('my_tle_1', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_1() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$);
+SELECT pgtle.install_extension('my_tle_2', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_2() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{my_tle_1}');
+SELECT pgtle.install_extension('my_tle_3', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_3() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{}', 'my_tle_schema_1');
+SELECT pgtle.install_extension('my_tle_4', '1.0', 'My TLE',
+    $_pgtle_$
+        CREATE OR REPLACE FUNCTION my_tle_func_4() RETURNS INT LANGUAGE SQL AS
+            'SELECT 1';
+    $_pgtle_$,
+    '{my_tle_3}', 'my_tle_schema_2');
+
+-- Create all the extensions.
+CREATE EXTENSION my_tle_1;
+CREATE EXTENSION my_tle_2;
+CREATE EXTENSION my_tle_3;
+CREATE EXTENSION my_tle_4;
+
+-- Validate the output of these functions.
+SELECT * from pgtle.available_extensions();
+SELECT * from pgtle.available_extension_versions();
+\dx
+
+-- Clean up.
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP SCHEMA my_tle_schema_1;
+DROP SCHEMA my_tle_schema_2;

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -6,12 +6,14 @@
 /*
  * 1. If an extension is created on pg_tle 1.4.1 and pg_tle is upgraded to
  *    1.5.0, the extension behaves like a regular schema-less extension.
+ *    pgtle.available_extensions() works on both 1.4.1 and 1.5.0.
  *
  * 2. If an extension is installed with a specified schema, it cannot be created
- *    in a different schema.
+ *    in a different schema. The extension objects are automatically created in
+ *    the specified schema.
  *
- * 3. If an extension is installed with a specified schema, it cannot be created
- *    if the schema does not exist.
+ * 3. If an extension is installed with a specified schema, the schema is
+ *    automatically created when the extension is created.
  *
  * 4. pgtle.available_extensions() and pgtle.available_extension_versions()
  *    print the correct output for a variety of extensions.
@@ -22,6 +24,7 @@
 /*
  * 1. If an extension is installed on pg_tle 1.4.1 and pg_tle is upgraded to
  *    1.5.0, the extension behaves like a regular schema-less extension.
+ *    pgtle.available_extensions() works on both 1.4.1 and 1.5.0.
  */
 
 CREATE SCHEMA my_tle_schema_1;
@@ -43,9 +46,14 @@ DROP EXTENSION my_tle CASCADE;
 
 -- Upgrade pg_tle to 1.5.0 and repeat the test.
 ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
+SELECT * FROM pgtle.available_extensions();
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
 ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
 SELECT my_tle_schema_1.my_tle_func();
+
+-- By specifying the columns explicitly, we can get the same output from
+-- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
+SELECT name, default_version, comment FROM pgtle.available_extensions();
 
 -- Clean up.
 DROP EXTENSION my_tle CASCADE;

--- a/test/sql/pg_tle_functions_acl.sql
+++ b/test/sql/pg_tle_functions_acl.sql
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * 1) Verify that an unprivileged user has the expected EXECUTE permissions on
+ * each pg_tle function.  All new SQL functions should be added to this test.
+ *
+ * If the function is not executable by the unprivileged user, we expect the
+ * exact error "permission denied for function <function_name>".  If a different
+ * error is thrown (except for syntax errors), that means the unprivileged user
+ * has EXECUTE permission.
+ * 
+ * 2) Verify that a pgtle_admin user has EXECUTE permission on each pg_tle
+ * function.
+ */
+
+-- Set up.
+CREATE EXTENSION pg_tle;
+CREATE USER acl_user;
+GRANT CREATE ON SCHEMA public TO acl_user;
+SET SESSION AUTHORIZATION acl_user;
+
+CREATE FUNCTION datin(t text) RETURNS bytea LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT pg_catalog.convert_to(t, 'UTF8');
+$$;
+CREATE FUNCTION datout(b bytea) RETURNS text LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT pg_catalog.convert_from(b, 'UTF8');
+$$;
+CREATE FUNCTION op(b bytea) RETURNS boolean LANGUAGE SQL IMMUTABLE AS
+$$
+    SELECT false;
+$$;
+
+/*
+ * 1. Test unprivileged user permissions.
+ */
+
+-- Unprivileged user can execute these functions.
+SELECT pgtle.available_extension_versions();
+SELECT pgtle.available_extensions();
+SELECT pgtle.extension_update_paths('imaginary_extension');
+
+-- Unprivileged user cannot execute these functions.
+SELECT pgtle.create_base_type('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+SELECT pgtle.create_base_type_if_not_exists('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+SELECT pgtle.create_operator_func('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+SELECT pgtle.create_operator_func_if_not_exists('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+SELECT pgtle.create_shell_type('public', 'imaginary_type');
+SELECT pgtle.create_shell_type_if_not_exists('public', 'imaginary_type');
+SELECT pgtle.install_extension('', '', '', '');
+SELECT pgtle.install_extension_version_sql('', '', '');
+SELECT pgtle.register_feature('op(bytea)'::regprocedure, 'passcheck');
+SELECT pgtle.register_feature_if_not_exists('op(bytea)'::regprocedure,
+    'passcheck');
+SELECT pgtle.set_default_version('', '');
+SELECT pgtle.uninstall_extension('');
+SELECT pgtle.uninstall_extension('', '');
+SELECT pgtle.uninstall_extension_if_exists('');
+SELECT pgtle.uninstall_update_path('', '', '');
+SELECT pgtle.uninstall_update_path_if_exists('', '', '');
+SELECT pgtle.unregister_feature('op(bytea)'::regprocedure, 'passcheck');
+SELECT pgtle.unregister_feature_if_exists('op(bytea)'::regprocedure,
+    'passcheck');
+
+/*
+ * 2. Test pgtle_admin user permissions.
+ */
+
+RESET SESSION AUTHORIZATION;
+GRANT pgtle_admin TO acl_user;
+SET SESSION AUTHORIZATION acl_user;
+
+-- pgtle_admin can execute all functions.
+SELECT pgtle.available_extension_versions();
+SELECT pgtle.available_extensions();
+SELECT pgtle.extension_update_paths('imaginary_extension');
+SELECT pgtle.create_base_type('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+SELECT pgtle.create_base_type_if_not_exists('public', 'imaginary_type',
+    'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
+SELECT pgtle.create_operator_func('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+SELECT pgtle.create_operator_func_if_not_exists('public', 'imaginary_type',
+    'op(bytea)'::regprocedure);
+SELECT pgtle.create_shell_type('public', 'imaginary_type');
+SELECT pgtle.create_shell_type_if_not_exists('public', 'imaginary_type');
+SELECT pgtle.install_extension('', '', '', '');
+SELECT pgtle.install_extension_version_sql('', '', '');
+SELECT pgtle.register_feature('op(bytea)'::regprocedure, 'passcheck');
+SELECT pgtle.register_feature_if_not_exists('op(bytea)'::regprocedure,
+    'passcheck');
+SELECT pgtle.set_default_version('', '');
+SELECT pgtle.uninstall_extension('');
+SELECT pgtle.uninstall_extension('', '');
+SELECT pgtle.uninstall_extension_if_exists('');
+SELECT pgtle.uninstall_update_path('', '', '');
+SELECT pgtle.uninstall_update_path_if_exists('', '', '');
+SELECT pgtle.unregister_feature('op(bytea)'::regprocedure, 'passcheck');
+SELECT pgtle.unregister_feature_if_exists('op(bytea)'::regprocedure,
+    'passcheck');
+
+-- Clean up.
+DROP FUNCTION datin;
+DROP FUNCTION datout;
+DROP FUNCTION op;
+DROP TYPE imaginary_type;
+RESET SESSION AUTHORIZATION;
+REVOKE CREATE ON SCHEMA public FROM acl_user;
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP USER acl_user;

--- a/test/sql/pg_tle_functions_acl.sql
+++ b/test/sql/pg_tle_functions_acl.sql
@@ -18,6 +18,8 @@
 
 -- Set up.
 CREATE EXTENSION pg_tle;
+SELECT pgtle.install_extension('test_ext', '1.0', '', '');
+
 CREATE USER acl_user;
 GRANT CREATE ON SCHEMA public TO acl_user;
 SET SESSION AUTHORIZATION acl_user;
@@ -42,7 +44,7 @@ $$;
 -- Unprivileged user can execute these functions.
 SELECT pgtle.available_extension_versions();
 SELECT pgtle.available_extensions();
-SELECT pgtle.extension_update_paths('imaginary_extension');
+SELECT pgtle.extension_update_paths('test_ext');
 
 -- Unprivileged user cannot execute these functions.
 SELECT pgtle.create_base_type('public', 'imaginary_type',
@@ -81,7 +83,7 @@ SET SESSION AUTHORIZATION acl_user;
 -- pgtle_admin can execute all functions.
 SELECT pgtle.available_extension_versions();
 SELECT pgtle.available_extensions();
-SELECT pgtle.extension_update_paths('imaginary_extension');
+SELECT pgtle.extension_update_paths('test_ext');
 SELECT pgtle.create_base_type('public', 'imaginary_type',
     'datin(text)'::regprocedure, 'datout(bytea)'::regprocedure, -1);
 SELECT pgtle.create_base_type_if_not_exists('public', 'imaginary_type',
@@ -114,6 +116,7 @@ DROP FUNCTION op;
 DROP TYPE imaginary_type;
 RESET SESSION AUTHORIZATION;
 REVOKE CREATE ON SCHEMA public FROM acl_user;
+SELECT pgtle.uninstall_extension('test_ext');
 DROP EXTENSION pg_tle CASCADE;
 DROP SCHEMA pgtle;
 DROP USER acl_user;

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -408,9 +408,9 @@ like  ($stdout, qr/t/, 'operator_from_restored_db');
 $stdout = $node->safe_psql($restored_db, q[SELECT * FROM pgtle.available_extensions() WHERE name = 'my_tle_with_schema']);
 is($stdout, q[my_tle_with_schema|1.0|My TLE with schema]);
 $stdout = $node->safe_psql($restored_db, q[
-    SELECT nspname FROM pg_namespace AS pgn INNER JOIN pg_extension AS pge
-    ON pge.extnamespace = pgn.oid
-    AND pge.extname = 'my_tle_with_schema']);
+    SELECT nspname FROM pg_namespace AS n INNER JOIN pg_extension AS e
+    ON e.extnamespace = n.oid
+    AND e.extname = 'my_tle_with_schema']);
 is($stdout, q[my_tle_schema]);
 
 # Test complete


### PR DESCRIPTION
Issue #284:

Description of changes:

Added optional _schema_ parameter to install_extension function and implemented adding _schema_ configuration to generated control file.
Updated current extension version to 1.5.0 as the change is not forward compatible. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
