### PR TITLE
Install libreadline-dev in CI workflow

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout Postgres
         run: |
-          sudo apt-get -y -q install libperl-dev libipc-run-perl lcov
+          sudo apt-get -y -q install libperl-dev libipc-run-perl lcov libreadline-dev
           git clone --branch ${{ matrix.version }} https://github.com/postgres/postgres.git
 
       - name: Build Postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Postgres
         run: |
           sudo apt-get -y -q update
-          sudo apt-get -y -q install libperl-dev libipc-run-perl
+          sudo apt-get -y -q install libperl-dev libipc-run-perl libreadline-dev
           git clone --branch ${{ matrix.version }} https://github.com/postgres/postgres.git
 
       - name: Build Postgres


### PR DESCRIPTION
Issue #, if available:

Description of changes: The new Ubuntu 24.04 image removed readline by default which broke Postgres compilation.

https://github.com/actions/runner-images/issues/10636

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
