### PR TITLE
Change return signature of `pgtle.available_extensions()` to match `pgtle.available_extension_versions()`.

### DIFF
--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -46,6 +46,11 @@ None.
 
 * `name`: The name of the extension.
 * `default_version`: The version of the extension to use when `CREATE EXTENSION` is called without a version.
+* `superuser`: This is always `false` for a pg_tle-compatible extension.
+* `trusted`: This is always `false` for a pg_tle-compatible extension.
+* `relocatable`: This is always `false` for a pg_tle-compatible extension.
+* `schema`: This is set if the extension must be installed into a specific schema.
+* `requires`: An array of extension names that this extension depends on.
 * `comment`: A more detailed description about the extension.
 
 #### Example
@@ -109,7 +114,7 @@ None.
 SELECT * FROM pgtle.extension_update_paths('pg_tle_test');
 ```
 
-### `pgtle.install_extension(name text, version text, description text, ext text, requires text[] DEFAULT NULL::text[])`
+### `pgtle.install_extension(name text, version text, description text, ext text, requires text[] DEFAULT NULL::text[], schema text DEFAULT NULL)`
 
 `install_extension` lets users install a `pg_tle`-compatible extensions and make them available within a database.
 
@@ -126,6 +131,7 @@ This functions returns `'OK'` on success and an error otherwise..
 * `description`: A detailed description about the extension. This is displayed in the `comment` field in `pgtle.available_extensions()`.
 * `ext`: The contents of the extension. This contains objects such as functions.
 * `requires`: An optional parameter that specifies dependencies for this extension. `pg_tle` is automatically added as a dependency.
+* `schema`: An optional parameter that specifies the schema that the extension must be installed in.
 
 Many of the above values are part of the [extension control file](https://www.postgresql.org/docs/current/extend-extensions.html#id-1.8.3.20.11) used to provide information about how to install a PostgreSQL extension. For more information about how each of these values work, please see the PostgreSQL documentation on [extension control files](https://www.postgresql.org/docs/current/extend-extensions.html#id-1.8.3.20.11).
 

--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -32,7 +32,7 @@ If a schema is not specified in a `pg_tle`-compatible extension, all objects (e.
 
 ### `pgtle.available_extensions()`
 
-`available_extensions` is a set-returning functions that returns a list of all available Trusted Language Extensions in a database. Each row contains information about a single extension.
+`available_extensions` is a set-returning function that returns a list of all available Trusted Language Extensions in a database. Each row contains information about a single extension.
 
 #### Role
 
@@ -61,7 +61,7 @@ SELECT * FROM pgtle.available_extensions();
 
 ### `pgtle.available_extension_versions()`
 
-`available_extension_versions` is a set-returning functions that returns a list of all available Trusted Language Extensions and their versions. Each row contains information about an individual version of an extension, including if it requires additional privileges for installation.
+`available_extension_versions` is a set-returning function that returns a list of all available Trusted Language Extensions and their versions. Each row contains information about an individual version of an extension, including if it requires additional privileges for installation.
 
 For more information on the output values, please read the [extension files](https://www.postgresql.org/docs/current/extend-extensions.html#id-1.8.3.20.11) section in the PostgreSQL documentation.
 
@@ -92,7 +92,7 @@ SELECT * FROM pgtle.available_extension_versions();
 
 ### `pgtle.extension_update_paths(name text)`
 
-`extension_update_paths` is a set-returning functions that returns a list of all the possible update paths for a Trusted Language Extension. Each row shows the path for how to upgrade/downgrade an extension.
+`extension_update_paths` is a set-returning function that returns a list of all the possible update paths for a Trusted Language Extension. Each row shows the path for how to upgrade/downgrade an extension.
 
 #### Role
 

--- a/pg_tle--1.4.1--1.5.0.sql
+++ b/pg_tle--1.4.1--1.5.0.sql
@@ -59,3 +59,25 @@ GRANT EXECUTE ON FUNCTION pgtle.install_extension
   requires text[],
   schema text
 ) TO pgtle_admin;
+
+DROP FUNCTION pgtle.available_extensions
+(
+  OUT name name,
+  OUT default_version text,
+  OUT comment text
+);
+
+CREATE FUNCTION pgtle.available_extensions
+(
+  OUT name name,
+  OUT default_version text,
+  OUT superuser boolean,
+  OUT trusted boolean,
+  OUT relocatable boolean,
+  OUT schema name,
+  OUT requires name[],
+  OUT comment text
+)
+RETURNS SETOF RECORD
+AS 'MODULE_PATHNAME', 'pg_tle_available_extensions'
+LANGUAGE C STABLE STRICT;

--- a/test/expected/pg_tle_extension_schema.out
+++ b/test/expected/pg_tle_extension_schema.out
@@ -56,9 +56,9 @@ DROP EXTENSION my_tle CASCADE;
 -- Upgrade pg_tle to 1.5.0 and repeat the test.
 ALTER EXTENSION pg_tle UPDATE TO '1.5.0';
 SELECT * FROM pgtle.available_extensions() ORDER BY name;
-  name  | default_version | comment 
---------+-----------------+---------
- my_tle | 1.0             | My TLE
+  name  | default_version | superuser | trusted | relocatable | schema | requires | comment 
+--------+-----------------+-----------+---------+-------------+--------+----------+---------
+ my_tle | 1.0             | f         | f       | f           |        | {pg_tle} | My TLE
 (1 row)
 
 CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
@@ -68,6 +68,14 @@ SELECT my_tle_schema_1.my_tle_func();
  my_tle_func 
 -------------
            1
+(1 row)
+
+-- By specifying the columns explicitly, we can get the same output from
+-- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
+SELECT name, default_version, comment FROM pgtle.available_extensions();
+  name  | default_version | comment 
+--------+-----------------+---------
+ my_tle | 1.0             | My TLE
 (1 row)
 
 -- Clean up.
@@ -99,9 +107,9 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
 (1 row)
 
 SELECT * FROM pgtle.available_extensions() ORDER BY name;
-  name  | default_version | comment 
---------+-----------------+---------
- my_tle | 1.0             | My TLE
+  name  | default_version | superuser | trusted | relocatable |     schema      | requires | comment 
+--------+-----------------+-----------+---------+-------------+-----------------+----------+---------
+ my_tle | 1.0             | f         | f       | f           | my_tle_schema_1 | {pg_tle} | My TLE
 (1 row)
 
 -- my_tle cannot be installed in my_tle_schema_2.
@@ -141,9 +149,9 @@ SELECT pgtle.install_extension('my_tle', '1.0', 'My TLE',
 (1 row)
 
 SELECT * FROM pgtle.available_extensions() ORDER BY name;
-  name  | default_version | comment 
---------+-----------------+---------
- my_tle | 1.0             | My TLE
+  name  | default_version | superuser | trusted | relocatable |     schema      | requires | comment 
+--------+-----------------+-----------+---------+-------------+-----------------+----------+---------
+ my_tle | 1.0             | f         | f       | f           | my_tle_schema_1 | {pg_tle} | My TLE
 (1 row)
 
 CREATE EXTENSION my_tle;
@@ -226,12 +234,12 @@ CREATE EXTENSION my_tle_3;
 CREATE EXTENSION my_tle_4;
 -- Validate the output of these functions.
 SELECT * FROM pgtle.available_extensions() ORDER BY name;
-   name   | default_version | comment 
-----------+-----------------+---------
- my_tle_1 | 1.0             | My TLE
- my_tle_2 | 1.0             | My TLE
- my_tle_3 | 1.0             | My TLE
- my_tle_4 | 1.0             | My TLE
+   name   | default_version | superuser | trusted | relocatable |     schema      |     requires      | comment 
+----------+-----------------+-----------+---------+-------------+-----------------+-------------------+---------
+ my_tle_1 | 1.0             | f         | f       | f           |                 | {pg_tle}          | My TLE
+ my_tle_2 | 1.0             | f         | f       | f           |                 | {my_tle_1,pg_tle} | My TLE
+ my_tle_3 | 1.0             | f         | f       | f           | my_tle_schema_1 | {pg_tle}          | My TLE
+ my_tle_4 | 1.0             | f         | f       | f           | my_tle_schema_2 | {my_tle_3,pg_tle} | My TLE
 (4 rows)
 
 SELECT * from pgtle.available_extension_versions() ORDER BY name;

--- a/test/expected/pg_tle_functions_acl.out
+++ b/test/expected/pg_tle_functions_acl.out
@@ -48,9 +48,9 @@ SELECT pgtle.available_extension_versions();
 (1 row)
 
 SELECT pgtle.available_extensions();
- available_extensions 
-----------------------
- (test_ext,1.0,"")
+       available_extensions        
+-----------------------------------
+ (test_ext,1.0,f,f,f,,{pg_tle},"")
 (1 row)
 
 SELECT pgtle.extension_update_paths('test_ext');
@@ -115,9 +115,9 @@ SELECT pgtle.available_extension_versions();
 (1 row)
 
 SELECT pgtle.available_extensions();
- available_extensions 
-----------------------
- (test_ext,1.0,"")
+       available_extensions        
+-----------------------------------
+ (test_ext,1.0,f,f,f,,{pg_tle},"")
 (1 row)
 
 SELECT pgtle.extension_update_paths('test_ext');

--- a/test/expected/pg_tle_management.out
+++ b/test/expected/pg_tle_management.out
@@ -198,10 +198,10 @@ SELECT * FROM pgtle.extension_update_paths('test123');
 (2 rows)
 
 SELECT * FROM pgtle.available_extensions() ORDER BY name;
-                   name                   | default_version |      comment       
-------------------------------------------+-----------------+--------------------
- test123                                  | 1.0             | Test TLE Functions
- test_no_switch_to_superuser_when_trusted | 1.0             | Test TLE Functions
+                   name                   | default_version | superuser | trusted | relocatable | schema | requires |      comment       
+------------------------------------------+-----------------+-----------+---------+-------------+--------+----------+--------------------
+ test123                                  | 1.0             | f         | f       | f           |        | {pg_tle} | Test TLE Functions
+ test_no_switch_to_superuser_when_trusted | 1.0             | f         | f       | f           |        | {pg_tle} | Test TLE Functions
 (2 rows)
 
 SELECT * FROM pgtle.available_extension_versions() ORDER BY name;
@@ -513,9 +513,9 @@ $_pgtle_$
 
 -- test the default version, should be 1.0
 SELECT * FROM pgtle.available_extensions() x WHERE x.name = 'new_ext';
-  name   | default_version |      comment       
----------+-----------------+--------------------
- new_ext | 1.0             | Test TLE Functions
+  name   | default_version | superuser | trusted | relocatable | schema | requires |      comment       
+---------+-----------------+-----------+---------+-------------+--------+----------+--------------------
+ new_ext | 1.0             | f         | f       | f           |        | {pg_tle} | Test TLE Functions
 (1 row)
 
 -- set the new default
@@ -527,9 +527,9 @@ SELECT pgtle.set_default_version('new_ext', '1.1');
 
 -- test the default version, should be 1.1
 SELECT * FROM pgtle.available_extensions() x WHERE x.name = 'new_ext';
-  name   | default_version |      comment       
----------+-----------------+--------------------
- new_ext | 1.1             | Test TLE Functions
+  name   | default_version | superuser | trusted | relocatable | schema | requires |      comment       
+---------+-----------------+-----------+---------+-------------+--------+----------+--------------------
+ new_ext | 1.1             | f         | f       | f           |        | {pg_tle} | Test TLE Functions
 (1 row)
 
 -- try setting a default version that does not exist
@@ -835,9 +835,9 @@ $_pgtle_$
 (1 row)
 
 SELECT pgtle.available_extensions();
-        available_extensions        
-------------------------------------
- (foo@bar,1.0,"Test TLE Functions")
+                available_extensions                
+----------------------------------------------------
+ (foo@bar,1.0,f,f,f,,{pg_tle},"Test TLE Functions")
 (1 row)
 
 CREATE EXTENSION "foo@bar";

--- a/test/sql/pg_tle_extension_schema.sql
+++ b/test/sql/pg_tle_extension_schema.sql
@@ -51,6 +51,10 @@ CREATE EXTENSION my_tle SCHEMA my_tle_schema_1;
 ALTER EXTENSION my_tle SET SCHEMA my_tle_schema_2;
 SELECT my_tle_schema_1.my_tle_func();
 
+-- By specifying the columns explicitly, we can get the same output from
+-- pgtle.available_extensions() in 1.5.0 as in 1.4.1.
+SELECT name, default_version, comment FROM pgtle.available_extensions();
+
 -- Clean up.
 DROP EXTENSION my_tle CASCADE;
 SELECT pgtle.uninstall_extension('my_tle');

--- a/test/t/002_pg_tle_dump_restore.pl
+++ b/test/t/002_pg_tle_dump_restore.pl
@@ -406,7 +406,7 @@ like  ($stdout, qr/t/, 'operator_from_restored_db');
 # 7. Verify TLE in custom schema
 
 $stdout = $node->safe_psql($restored_db, q[SELECT * FROM pgtle.available_extensions() WHERE name = 'my_tle_with_schema']);
-is($stdout, q[my_tle_with_schema|1.0|My TLE with schema]);
+is($stdout, q[my_tle_with_schema|1.0|f|f|f|my_tle_schema|{pg_tle}|My TLE with schema]);
 $stdout = $node->safe_psql($restored_db, q[
     SELECT nspname FROM pg_namespace AS n INNER JOIN pg_extension AS e
     ON e.extnamespace = n.oid


### PR DESCRIPTION
Description of changes: `pgtle.available_extension_versions()` returns more fields than `pgtle.available_extensions()` including the schema field which can now be modified. It doesn't really make sense for the two functions to return different signatures, so add those missing fields to `pgtle.available_extensions()`.

This changes the output returned by `SELECT * FROM pgtle.available_extensions()` so callers should be aware of that. However, the output is identical if the three columns from before are specified, i.e `SELECT name, default_version, comment FROM pgtle.available_extensions()`. This change is part of the 1.5.0 minor version bump.

Add the updated functions to the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
