### PR TITLE
Fix pgtle.install_extension_version_sql example

### DIFF
--- a/docs/03_managing_extensions.md
+++ b/docs/03_managing_extensions.md
@@ -173,12 +173,11 @@ The extension control file for the specified extension must already be installed
 #### Example
 
 ```sql
-SELECT pgtle.install_extension(
+SELECT pgtle.install_extension_version_sql(
  'pg_tle_test',
  '0.2',
- 'A new version of my pg_tle extension',
 $_pgtle_$
-  CREATE FUNCTION my_test()
+  CREATE OR REPLACE FUNCTION my_test()
   RETURNS INT
   AS $$
     SELECT 4242;


### PR DESCRIPTION
Issue #, if available: #281

Description of changes: Fix example of `pgtle.install_extension_version_sql` in `03_managing_extensions.md`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
