### PR TITLE
Update CreateQueryDesc signature on PG18.

### DIFF
--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1177,6 +1177,9 @@ execute_sql_string(const char *sql)
 				QueryDesc  *qdesc;
 
 				qdesc = CreateQueryDesc(stmt,
+#if PG_VERSION_NUM >= 180000
+										NULL,
+#endif
 										sql,
 										GetActiveSnapshot(), NULL,
 										dest, NULL, NULL, 0);


### PR DESCRIPTION
Description of changes: Fix CI build on Postgres master branch. The signature of CreateQueryDesc is updated in [525392d5727](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=525392d5727).

The new parameter lets you provide a CachedPlan. Prior to this commit, the CachedPlan is NULL by default. To preserve the previous behaviour we can just pass NULL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
