### PR TITLE
Additional parameter application_name to clientauth_port_subset (clientauth)

### DIFF
--- a/docs/04_hooks.md
+++ b/docs/04_hooks.md
@@ -209,7 +209,7 @@ A `clientauth` hook function takes the following arguments and returns either `t
 
 clientauth_hook(port pgtle.clientauth_port_subset, status integer)
 
-* `port` (`pgtle.clientauth_port_subset`) - an object containing the following fields. These are a subset of the Port object that client authentication hook passes to internal C functions.
+* `port` (`pgtle.clientauth_port_subset`) - an object containing the following fields. These are a subset of the [Port](https://doxygen.postgresql.org/structPort.html) object that client authentication hook passes to internal C functions.
   * `noblock` (`bool`)
   * `remote_host` (`text`)
   * `remote_hostname` (`text`)
@@ -217,6 +217,7 @@ clientauth_hook(port pgtle.clientauth_port_subset, status integer)
   * `remote_hostname_errcode` (`integer`)
   * `database_name` (`text`)
   * `user_name` (`text`)
+  * `application_name` (`text`)
 * `status` (`integer`) - connection status code. This can be one of the following:
   * 0, representing successful connection
   * -1, representing a connection error

--- a/include/constants.h
+++ b/include/constants.h
@@ -36,6 +36,8 @@
 #define TLE_INPUT_FUNC_STR       "input"
 #define TLE_OUTPUT_FUNC_STR      "output"
 
+#define TLE_CLIENTAUTH_PORT_SUBSET_TYPE	"clientauth_port_subset"
+
 /*
  * TLE_BASE_TYPE_SIZE_LIMIT is the maximum allowed size of pg_tle type.
  *

--- a/pg_tle--1.4.1--1.5.0.sql
+++ b/pg_tle--1.4.1--1.5.0.sql
@@ -81,3 +81,17 @@ CREATE FUNCTION pgtle.available_extensions
 RETURNS SETOF RECORD
 AS 'MODULE_PATHNAME', 'pg_tle_available_extensions'
 LANGUAGE C STABLE STRICT;
+
+DROP TYPE pgtle.clientauth_port_subset;
+
+CREATE TYPE pgtle.clientauth_port_subset AS (
+    noblock                 boolean,
+    remote_host             text,
+    remote_hostname         text,
+    remote_hostname_resolv  integer,
+    remote_hostname_errcode integer,
+    database_name           text,
+    user_name               text,
+    application_name        text
+);
+

--- a/pg_tle--1.4.1--1.5.0.sql
+++ b/pg_tle--1.4.1--1.5.0.sql
@@ -82,16 +82,5 @@ RETURNS SETOF RECORD
 AS 'MODULE_PATHNAME', 'pg_tle_available_extensions'
 LANGUAGE C STABLE STRICT;
 
-DROP TYPE pgtle.clientauth_port_subset;
-
-CREATE TYPE pgtle.clientauth_port_subset AS (
-    noblock                 boolean,
-    remote_host             text,
-    remote_hostname         text,
-    remote_hostname_resolv  integer,
-    remote_hostname_errcode integer,
-    database_name           text,
-    user_name               text,
-    application_name        text
-);
-
+ALTER TYPE pgtle.clientauth_port_subset
+ADD ATTRIBUTE application_name text;

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -97,53 +97,6 @@
  */
 #define CLIENT_AUTH_USER_ERROR_MAX_STRLEN 256
 
-static const char *clientauth_shmem_name = "pgtle_clientauth";
-static const char *clientauth_feature = "clientauth";
-static const char *clientauth_worker_name = "pg_tle_clientauth worker";
-
-/* Background worker main entry function */
-PGDLLEXPORT void clientauth_launcher_main(Datum arg);
-
-/* Set up our hooks */
-static ClientAuthentication_hook_type prev_clientauth_hook = NULL;
-static void clientauth_hook(Port *port, int status);
-
-static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
-static void clientauth_shmem_startup(void);
-
-#if (PG_VERSION_NUM >= 150000)
-static shmem_request_hook_type prev_shmem_request_hook = NULL;
-static void clientauth_shmem_request(void);
-#endif
-
-/* Helper functions */
-static Size clientauth_shared_memsize(void);
-static void clientauth_sighup(SIGNAL_ARGS);
-
-void		clientauth_init(void);
-static bool can_allow_without_executing(void);
-static bool can_reject_without_executing(void);
-
-static bool does_port_subset_contain_application_name_field(void);
-
-/* GUC that determines whether clientauth is enabled */
-static int	enable_clientauth_feature = FEATURE_OFF;
-
-/* GUC that determines which database SPI_exec runs against */
-static char *clientauth_database_name = "postgres";
-
-/* GUC that determines the number of background workers */
-static int	clientauth_num_parallel_workers = 1;
-
-/* GUC that determines users that clientauth feature skips */
-static char *clientauth_users_to_skip = "";
-
-/* GUC that determines databases that clientauth feature skips */
-static char *clientauth_databases_to_skip = "";
-
-/* Global flags */
-static bool clientauth_reload_config = false;
-
 /*
  * Fixed-length subset of Port, passed to user function. A corresponding SQL
  * base type is defined. Shared memory structs are required to be fixed-size,
@@ -236,6 +189,53 @@ typedef struct ClientAuthBgwShmemSharedState
 	/* Connection queue state */
 	ClientAuthStatusEntry requests[CLIENT_AUTH_MAX_PENDING_ENTRIES];
 }			ClientAuthBgwShmemSharedState;
+
+static const char *clientauth_shmem_name = "pgtle_clientauth";
+static const char *clientauth_feature = "clientauth";
+static const char *clientauth_worker_name = "pg_tle_clientauth worker";
+
+/* Background worker main entry function */
+PGDLLEXPORT void clientauth_launcher_main(Datum arg);
+
+/* Set up our hooks */
+static ClientAuthentication_hook_type prev_clientauth_hook = NULL;
+static void clientauth_hook(Port *port, int status);
+
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+static void clientauth_shmem_startup(void);
+
+#if (PG_VERSION_NUM >= 150000)
+static shmem_request_hook_type prev_shmem_request_hook = NULL;
+static void clientauth_shmem_request(void);
+#endif
+
+/* Helper functions */
+static Size clientauth_shared_memsize(void);
+static void clientauth_sighup(SIGNAL_ARGS);
+
+void		clientauth_init(void);
+static bool can_allow_without_executing(void);
+static bool can_reject_without_executing(void);
+
+static char *create_port_subset_str(PortSubset * port);
+
+/* GUC that determines whether clientauth is enabled */
+static int	enable_clientauth_feature = FEATURE_OFF;
+
+/* GUC that determines which database SPI_exec runs against */
+static char *clientauth_database_name = "postgres";
+
+/* GUC that determines the number of background workers */
+static int	clientauth_num_parallel_workers = 1;
+
+/* GUC that determines users that clientauth feature skips */
+static char *clientauth_users_to_skip = "";
+
+/* GUC that determines databases that clientauth feature skips */
+static char *clientauth_databases_to_skip = "";
+
+/* Global flags */
+static bool clientauth_reload_config = false;
 
 static ClientAuthBgwShmemSharedState * clientauth_ss = NULL;
 
@@ -591,25 +591,7 @@ clientauth_launcher_run_user_functions(bool *error, char (*error_msg)[CLIENT_AUT
 						 func_name,
 						 quote_identifier(PG_TLE_NSPNAME));
 
-		if (does_port_subset_contain_application_name_field())
-			port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s,%s)",
-									   port->noblock,
-									   quote_identifier(port->remote_host),
-									   quote_identifier(port->remote_hostname),
-									   port->remote_hostname_resolv,
-									   port->remote_hostname_errcode,
-									   quote_identifier(port->database_name),
-									   quote_identifier(port->user_name),
-									   quote_identifier(port->application_name));
-		else
-			port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s)",
-									   port->noblock,
-									   quote_identifier(port->remote_host),
-									   quote_identifier(port->remote_hostname),
-									   port->remote_hostname_resolv,
-									   port->remote_hostname_errcode,
-									   quote_identifier(port->database_name),
-									   quote_identifier(port->user_name));
+		port_subset_str = create_port_subset_str(port);
 
 		hookargs[0] = CStringGetTextDatum(port_subset_str);
 		hookargs[1] = Int32GetDatum(*status);
@@ -915,27 +897,47 @@ can_reject_without_executing()
 }
 
 /*
- * Returns true if the pgtle.clientauth_port_subset composite type contains the
- * `application_name` field.  This field was introduced in pg_tle 1.5.0.
+ * Constructs a string representation of the PortSubset composite type and
+ * returns it in an allocated string.  The signature of the PortSubset type
+ * varies based on the pg_tle version, so check the signature first.
  */
-static bool
-does_port_subset_contain_application_name_field()
+static char *
+create_port_subset_str(PortSubset * port)
 {
 	TupleDesc	tupdesc =
 		RelationNameGetTupleDesc(PG_TLE_NSPNAME "."
 								 TLE_CLIENTAUTH_PORT_SUBSET_TYPE);
+	char	   *port_subset_str;
 
 	if (tupdesc->natts == 7)
-		return false;
+		port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s)",
+								   port->noblock,
+								   quote_identifier(port->remote_host),
+								   quote_identifier(port->remote_hostname),
+								   port->remote_hostname_resolv,
+								   port->remote_hostname_errcode,
+								   quote_identifier(port->database_name),
+								   quote_identifier(port->user_name));
 	else if (tupdesc->natts == 8)
-		return true;
+		port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s,%s)",
+								   port->noblock,
+								   quote_identifier(port->remote_host),
+								   quote_identifier(port->remote_hostname),
+								   port->remote_hostname_resolv,
+								   port->remote_hostname_errcode,
+								   quote_identifier(port->database_name),
+								   quote_identifier(port->user_name),
+								   quote_identifier(port->application_name));
+	else
 
-	/*
-	 * Should be unreachable.  If we add more fields in the future, we need to
-	 * modify the logic above.
-	 */
-	ereport(ERROR,
-			errmsg("\"%s.clientauth\" feature encountered an unexpected number of fields in the \"%s.%s\" composite type: %d",
-				   PG_TLE_NSPNAME, PG_TLE_NSPNAME,
-				   TLE_CLIENTAUTH_PORT_SUBSET_TYPE, tupdesc->natts));
+		/*
+		 * Should be unreachable.  If we add more fields in the future, we
+		 * need to modify the logic above.
+		 */
+		ereport(ERROR,
+				errmsg("\"%s.clientauth\" feature encountered an unexpected number of fields in the \"%s.%s\" composite type: %d",
+					   PG_TLE_NSPNAME, PG_TLE_NSPNAME,
+					   TLE_CLIENTAUTH_PORT_SUBSET_TYPE, tupdesc->natts));
+
+	return port_subset_str;
 }

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -596,8 +596,7 @@ clientauth_launcher_run_user_functions(bool *error, char (*error_msg)[CLIENT_AUT
 								   port->remote_hostname_errcode,
 								   quote_identifier(port->database_name),
 								   quote_identifier(port->user_name),
-								   quote_identifier(port->application_name)
-								   );
+								   quote_identifier(port->application_name));
 
 		hookargs[0] = CStringGetTextDatum(port_subset_str);
 		hookargs[1] = Int32GetDatum(*status);

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -163,6 +163,7 @@ typedef struct PortSubset
 
 	char		database_name[CLIENT_AUTH_PORT_SUBSET_MAX_STRLEN];
 	char		user_name[CLIENT_AUTH_PORT_SUBSET_MAX_STRLEN];
+	char		application_name[CLIENT_AUTH_PORT_SUBSET_MAX_STRLEN];
 }			PortSubset;
 
 /* Represents a pending connection */
@@ -587,14 +588,16 @@ clientauth_launcher_run_user_functions(bool *error, char (*error_msg)[CLIENT_AUT
 						 func_name,
 						 quote_identifier(PG_TLE_NSPNAME));
 
-		port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s)",
+		port_subset_str = psprintf("(%d,%s,%s,%d,%d,%s,%s,%s)",
 								   port->noblock,
 								   quote_identifier(port->remote_host),
 								   quote_identifier(port->remote_hostname),
 								   port->remote_hostname_resolv,
 								   port->remote_hostname_errcode,
 								   quote_identifier(port->database_name),
-								   quote_identifier(port->user_name));
+								   quote_identifier(port->user_name),
+								   quote_identifier(port->application_name)
+								   );
 
 		hookargs[0] = CStringGetTextDatum(port_subset_str);
 		hookargs[1] = Int32GetDatum(*status);
@@ -718,6 +721,10 @@ clientauth_hook(Port *port, int status)
 			 CLIENT_AUTH_PORT_SUBSET_MAX_STRLEN,
 			 "%s",
 			 port->user_name == NULL ? "" : port->user_name);
+	snprintf(clientauth_ss->requests[idx].port_info.application_name,
+			 CLIENT_AUTH_PORT_SUBSET_MAX_STRLEN,
+			 "%s",
+			 port->application_name == NULL ? "" : port->application_name);
 	clientauth_ss->requests[idx].port_info.noblock = port->noblock;
 	clientauth_ss->requests[idx].port_info.remote_hostname_resolv = port->remote_hostname_resolv;
 	clientauth_ss->requests[idx].port_info.remote_hostname_errcode = port->remote_hostname_errcode;


### PR DESCRIPTION
Issue #, if available:
#290 

Description of changes:
Adding additional column application_name to the clientauth_port_subset.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
