### PR TITLE
Drop support for PG11 in pg_tle 1.5.0.

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ There are examples for writing TLEs in several languages, including:
 * [JavaScript](./docs/07_plv8_examples.md)
 * [Perl](./docs/08_plperl_examples.md)
 
+## Supported PostgreSQL versions
+
+`pg_tle` 1.5.0 supports PostgreSQL major versions 12 to 17.
+
+`pg_tle` 1.4.1 supports PostgreSQL major versions 11 to 17.
+
 ## Help & feedback
 
 Have a question? Have a feature request? We recommend trying the following things (in this order):


### PR DESCRIPTION
Description of changes: Doc and CI update to drop support for PG11 in pg_tle 1.5.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
