### PR TITLE
Reset GUCs at the end of regression tests.

### DIFF
--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -464,6 +464,15 @@ SELECT pgtle.unregister_feature('password_check_length_greater_than_8', 'clienta
 (1 row)
 
 -- now drop everything
+ALTER SYSTEM RESET pgtle.enable_password_check;
+ALTER SYSTEM RESET pgtle.passcheck_db_name;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c
 DROP FUNCTION password_check_length_greater_than_8;
 DROP SCHEMA pass CASCADE;
 NOTICE:  drop cascades to function pass.password_check_length_greater_than_8(text,text,pgtle.password_types,timestamp with time zone,boolean)

--- a/test/sql/pg_tle_api.sql
+++ b/test/sql/pg_tle_api.sql
@@ -267,6 +267,10 @@ SELECT pg_reload_conf();
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'clientauth');
 SELECT pgtle.unregister_feature('password_check_length_greater_than_8', 'clientauth');
 -- now drop everything
+ALTER SYSTEM RESET pgtle.enable_password_check;
+ALTER SYSTEM RESET pgtle.passcheck_db_name;
+SELECT pg_reload_conf();
+\c
 DROP FUNCTION password_check_length_greater_than_8;
 DROP SCHEMA pass CASCADE;
 DROP EXTENSION pg_tle;


### PR DESCRIPTION
Fixes spurious test failures if the test order is not as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
