### PR TITLE
Bump version to 1.5.2

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
+        version: [master, REL_18_STABLE, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
+        version: [master, REL_18_STABLE, REL_17_STABLE, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = pg_tle
-EXTVERSION = 1.5.0
+EXTVERSION = 1.5.2
 
 SCHEMA = pgtle
 MODULE_big = $(EXTENSION)
@@ -7,7 +7,9 @@ MODULE_big = $(EXTENSION)
 OBJS = src/tleextension.o src/guc-file.o src/feature.o src/passcheck.o src/uni_api.o src/datatype.o src/clientauth.o
 
 EXTRA_CLEAN	= src/guc-file.c pg_tle.control pg_tle--$(EXTVERSION).sql
-DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql pg_tle--1.0.4.sql pg_tle--1.0.4--1.1.1.sql pg_tle--1.1.0--1.1.1.sql pg_tle--1.1.1.sql pg_tle--1.1.1--1.2.0.sql pg_tle--1.2.0--1.3.0.sql pg_tle--1.3.0--1.3.3.sql pg_tle--1.3.3--1.3.4.sql pg_tle--1.3.4--1.4.0.sql pg_tle--1.4.0--1.5.0.sql
+DATA = pg_tle.control pg_tle--1.0.0.sql pg_tle--1.0.0--1.0.1.sql pg_tle--1.0.1--1.0.4.sql pg_tle--1.0.4.sql pg_tle--1.0.4--1.1.1.sql \
+			 pg_tle--1.1.0--1.1.1.sql pg_tle--1.1.1.sql pg_tle--1.1.1--1.2.0.sql pg_tle--1.2.0--1.3.0.sql pg_tle--1.3.0--1.3.3.sql \
+			 pg_tle--1.3.3--1.3.4.sql pg_tle--1.3.4--1.4.0.sql pg_tle--1.4.0--1.5.0.sql pg_tle--1.5.0--1.5.2.sql
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/pg_tle--1.5.0--1.5.2.sql
+++ b/pg_tle--1.5.0--1.5.2.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_tle" to load this file. \quit


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/pg_tle/issues/302

Description of changes:

This commit bumps the version from 1.5.0 to 1.5.2. Note that the version number was not updated in 1.5.1 release, https://github.com/aws/pg_tle/blob/v1.5.1/Makefile#L2, hence bumping to 1.5.2.

```
psql (18.0)
Type "help" for help.

postgres=# create extension pg_tle;
CREATE EXTENSION
postgres=# \dx
                                 List of installed extensions
  Name   | Version | Default version |   Schema   |                Description                 
---------+---------+-----------------+------------+--------------------------------------------
 pg_tle  | 1.5.2   | 1.5.2           | pgtle      | Trusted Language Extensions for PostgreSQL
 plpgsql | 1.0     | 1.0             | pg_catalog | PL/pgSQL procedural language
(2 rows)

postgres=#
```

This commit also enables CI test with REL_18_STABLE branch. CI test against postgres master branch is currently broken due to changes in upstream engine code. We will follow up to fix that separately in a different PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
