### PR TITLE
Add PostgreSQL 19 compatibility

### DIFF
--- a/include/clientauth.h
+++ b/include/clientauth.h
@@ -18,4 +18,4 @@
  * contains the changes needed by uni_api to load the functionality for
  * clientauth.
  */
-void		clientauth_init();
+void		clientauth_init(void);

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -382,7 +382,11 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 	CastCreate(sourcetypeid, targettypeid, funcid, castcontext, castmethod, behavior)
 #endif
 
-#if PG_VERSION_NUM >= 140000
+#if PG_VERSION_NUM >= 190000
+#define FUNCNAME_GET_CANDIDATES(names, nargs, argnames, expand_variadic, expand_defaults, missing_ok) \
+	({ int _fgc_flags = 0; \
+	   FuncnameGetCandidates(names, nargs, argnames, expand_variadic, expand_defaults, false /* include_out_arguments */, missing_ok, &_fgc_flags); })
+#elif PG_VERSION_NUM >= 140000
 #define FUNCNAME_GET_CANDIDATES(names, nargs, argnames, expand_variadic, expand_defaults, missing_ok) \
 	FuncnameGetCandidates(names, nargs, argnames, expand_variadic, expand_defaults, false /* include_out_arguments */, missing_ok)
 #else
@@ -633,6 +637,24 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 #else
 #define EXECUTOR_RUN(queryDesc, direction, count, execute_once) \
     ExecutorRun((queryDesc), (direction), (count), (execute_once))
+#endif
+
+/*
+ * PostgreSQL version 19
+ *
+ * pgstat.h no longer transitively includes utils/wait_event.h
+ * log_min_messages changed from int to int[]
+ * get_database_name moved to utils/lsyscache.h
+ * get_database_oid moved to catalog/pg_database.h
+ * CreateSchemaCommand signature changed to (ParseState*, CreateSchemaStmt*, int, int)
+ */
+#if (PG_VERSION_NUM >= 190000)
+#include "utils/wait_event.h"
+#include "catalog/pg_database.h"
+#include "utils/lsyscache.h"
+#define LOG_MIN_MESSAGES_VALUE log_min_messages[0]
+#else
+#define LOG_MIN_MESSAGES_VALUE log_min_messages
 #endif
 
 #endif							/* SET_USER_COMPAT_H */

--- a/include/passcheck.h
+++ b/include/passcheck.h
@@ -18,4 +18,4 @@
  * contains the changes needed by uni_api to load the functionality for
  * passcheck.
  */
-void		passcheck_init();
+void		passcheck_init(void);

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -831,7 +831,7 @@ clientauth_sighup(SIGNAL_ARGS)
  * 3. pgtle.enable_clientauth is ON and no functions are registered with the clientauth feature
  */
 static bool
-can_allow_without_executing()
+can_allow_without_executing(void)
 {
 	List	   *proc_names;
 	Oid			extOid;
@@ -865,7 +865,7 @@ can_allow_without_executing()
  * 2. pgtle.enable_clientauth is REQUIRE and no functions are registered with the clientauth feature
  */
 static bool
-can_reject_without_executing()
+can_reject_without_executing(void)
 {
 	List	   *proc_names;
 	Oid			extOid;

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -73,6 +73,9 @@
 #include "nodes/plannodes.h"
 #include "parser/parse_func.h"
 #include "parser/parse_type.h"
+#if PG_VERSION_NUM >= 190000
+#include "parser/parse_node.h"
+#endif
 #include "storage/fd.h"
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
@@ -86,6 +89,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/varlena.h"
+#include "utils/tuplestore.h"
 
 #include "constants.h"
 #include "tleextension.h"
@@ -1332,7 +1336,7 @@ execute_extension_script(Oid extensionOid, ExtensionControlFile *control,
 									 PGC_USERSET, PGC_S_SESSION,
 									 GetUserId(),
 									 GUC_ACTION_SAVE, true, 0, false);
-	if (log_min_messages < WARNING)
+	if (LOG_MIN_MESSAGES_VALUE < WARNING)
 		(void) set_config_option_ext("log_min_messages", "warning",
 									 PGC_SUSET, PGC_S_SESSION,
 									 BOOTSTRAP_SUPERUSERID,
@@ -2067,14 +2071,25 @@ CreateExtensionInternal(char *extensionName,
 
 		if (!OidIsValid(schemaOid))
 		{
+#if PG_VERSION_NUM >= 190000
+			ParseState *pstate = make_parsestate(NULL);
+#endif
 			CreateSchemaStmt *csstmt = makeNode(CreateSchemaStmt);
+
+#if PG_VERSION_NUM >= 190000
+			pstate->p_sourcetext = "(generated CREATE SCHEMA command)";
+#endif
 
 			csstmt->schemaname = schemaName;
 			csstmt->authrole = NULL;	/* will be created by current user */
 			csstmt->schemaElts = NIL;
 			csstmt->if_not_exists = false;
+#if PG_VERSION_NUM >= 190000
+			CreateSchemaCommand(pstate, csstmt, -1, -1);
+#else
 			CreateSchemaCommand(csstmt, "(generated CREATE SCHEMA command)",
 								-1, -1);
+#endif
 
 			/*
 			 * CreateSchemaCommand includes CommandCounterIncrement, so new

--- a/test/expected/pg_tle_versions_1.out
+++ b/test/expected/pg_tle_versions_1.out
@@ -1,0 +1,191 @@
+/*
+*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/*
+* 1. Test that an existing version of an extension cannot be installed again
+* 2. Test that a different version of an installed extension can be installed
+* 3. Test that CREATE EXTENSION with an explicit version automatically updates
+*    to that version
+* 4. Test that CREATE EXTENSION automatically updates to default version
+*/
+\pset pager off
+CREATE EXTENSION pg_tle;
+-- install version 1.0 of an extension
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 42
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           42
+(1 row)
+
+DROP EXTENSION test123;
+-- an existing version of an extension cannot be installed again
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.0',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ERROR:  extension "test123" already installed
+-- but a different version of the same extension can be installed
+SELECT pgtle.install_extension
+(
+ 'test123',
+ '1.1',
+ 'Test TLE Functions',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_extension 
+-------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
+-- uninstall version 1.1
+SELECT pgtle.set_default_version('test123', '1.0');
+ set_default_version 
+---------------------
+ t
+(1 row)
+
+SELECT pgtle.uninstall_extension('test123', '1.1');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           42
+(1 row)
+
+SELECT test123_func_2();    -- expect to fail
+ERROR:  function test123_func_2() does not exist
+LINE 1: SELECT test123_func_2();
+               ^
+DETAIL:  There is no function of that name.
+DROP EXTENSION test123;
+-- create update path to 1.1 instead
+SELECT pgtle.install_update_path
+(
+ 'test123',
+ '1.0',
+ '1.1',
+$_pgtle_$
+  CREATE OR REPLACE FUNCTION test123_func()
+  RETURNS INT AS $$
+  (
+    SELECT 21
+  )$$ LANGUAGE sql;
+  CREATE OR REPLACE FUNCTION test123_func_2()
+  RETURNS INT AS $$
+  (
+    SELECT 212121
+  )$$ LANGUAGE sql;
+$_pgtle_$
+);
+ install_update_path 
+---------------------
+ t
+(1 row)
+
+-- test that CREATE EXTENSION version 1.1 works
+CREATE EXTENSION test123 version '1.1';
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
+-- if version 1.1 is set as default, then it should be create-able via the upgrade path
+SELECT pgtle.set_default_version('test123', '1.1');
+ set_default_version 
+---------------------
+ t
+(1 row)
+
+CREATE EXTENSION test123;
+SELECT test123_func();
+ test123_func 
+--------------
+           21
+(1 row)
+
+SELECT test123_func_2();
+ test123_func_2 
+----------------
+         212121
+(1 row)
+
+DROP EXTENSION test123;
+-- sanity check that uninstall works
+SELECT pgtle.uninstall_extension('test123');
+ uninstall_extension 
+---------------------
+ t
+(1 row)
+
+-- clean up
+DROP EXTENSION pg_tle CASCADE;
+DROP SCHEMA pgtle;
+DROP ROLE pgtle_admin;


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/pg_tle/issues/305

Description of changes:

Add PostgreSQL 19 compatibility

- Add PG19 branch for FUNCNAME_GET_CANDIDATES macro to pass the new
  fgc_flags parameter added to FuncnameGetCandidates()

https://github.com/postgres/postgres/blob/master/src/include/catalog/namespace.h#L124

- Handle CreateSchemaCommand signature change to accept ParseState*
  instead of a raw query string
https://github.com/postgres/postgres/blob/master/src/include/commands/schemacmds.h#L23

- Wrap log_min_messages access in LOG_MIN_MESSAGES_VALUE macro to
  account for the int-to-int[] type change  
https://github.com/postgres/postgres/blob/da6874635db2e8ab95150481c992f03ec6094805/src/include/utils/guc.h#L298

- Include utils/wait_event.h, catalog/pg_database.h, and
  utils/lsyscache.h explicitly since they are no longer transitively
  included via pgstat.h

when we fixed above, the second complie with below errors
```
implicit declaration of function 'get_database_name', 'WAIT_EVENT_MESSAGE_QUEUE_RECEIVE' undeclared
```
- Add missing includes for parser/parse_node.h and utils/tuplestore.h


Also

PG19 changed the "function not found" error from HINT to DETAIL, which made the pg_tle_versions test output differ across versions. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
