### PR TITLE
Document PostgreSQL 18 support and apply pgindent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ There are examples for writing TLEs in several languages, including:
 
 ## Supported PostgreSQL versions
 
+`pg_tle` 1.5.2 supports PostgreSQL major versions 12 to 18.
+
 `pg_tle` 1.5.0 supports PostgreSQL major versions 12 to 17.
 
 `pg_tle` 1.4.0 supports PostgreSQL major versions 11 to 17.

--- a/include/compatibility.h
+++ b/include/compatibility.h
@@ -131,8 +131,10 @@
 #define GETOBJECTDESCRIPTION(a)		getObjectDescription(a, false)
 #endif
 
-/* if prior to pg13, upgrade to newer macro defs.
- * This also adds support for PG_FINALLY  */
+/*
+ * if prior to pg13, upgrade to newer macro defs.
+ * This also adds support for PG_FINALLY
+ */
 #if PG_VERSION_NUM < 130000
 #ifdef PG_TRY
 #undef PG_TRY

--- a/src/clientauth.c
+++ b/src/clientauth.c
@@ -519,7 +519,8 @@ clientauth_launcher_main(Datum arg)
 	}
 }
 
-/* Run the user's functions.
+/*
+ * Run the user's functions.
  *
  * This procedure should not do any transaction management (other than opening an SPI connection)
  * or shared memory accesses.

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -1888,11 +1888,11 @@ find_install_path(List *evi_list, ExtensionVersionInfo *evi_target,
 }
 
 /*
-* Figures out which script(s) we need to run to install the desired
-* version of the extension.  If we do not have a script that directly
-* does what is needed, we try to find a sequence of update scripts that
-* will get us there.
-*/
+ * Figures out which script(s) we need to run to install the desired
+ * version of the extension.  If we do not have a script that directly
+ * does what is needed, we try to find a sequence of update scripts that
+ * will get us there.
+ */
 static List *
 find_versions_to_apply(ExtensionControlFile *pcontrol, const char **versionName)
 {
@@ -5207,12 +5207,12 @@ pg_tle_set_default_version(PG_FUNCTION_ARGS)
 }
 
 /*
-* Convert text array to list of strings.
-*
-* Note: the resulting list of strings is pallocated here.
-*
-* This is borrowed from pg_subscription.c
-*/
+ * Convert text array to list of strings.
+ *
+ * Note: the resulting list of strings is pallocated here.
+ *
+ * This is borrowed from pg_subscription.c
+ */
 static List *
 textarray_to_stringlist(ArrayType *textarray)
 {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Two tidy-up changes, no functional code changes:

- Document PostgreSQL 18 support in the README. CI already builds and
  tests against REL_18_STABLE and the full regression suite passes on
  PG18, so the supported-versions list is updated to note that pg_tle
  1.5.2 supports PostgreSQL major versions 12 to 18.

- Apply pgindent to the source files (compatibility.h, clientauth.c,
  tleextension.c). This reformats a few block comments to satisfy the
  pgindent check that CI runs against the PostgreSQL master branch,
  fixing that CI job. No functional changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.