### PR TITLE
Fix -Wmissing-variable-declarations warnings on PG 18 / PG 19 builds

### DIFF
--- a/src/passcheck.c
+++ b/src/passcheck.c
@@ -81,7 +81,7 @@ static const char *passcheck_shmem_name = "pgtle_passcheck";
 
 
 /*  This should match crypt.h */
-char	   *pass_types[3] = {"PASSWORD_TYPE_PLAINTEXT", "PASSWORD_TYPE_MD5", "PASSWORD_TYPE_SCRAM_SHA_256"};
+static char *pass_types[3] = {"PASSWORD_TYPE_PLAINTEXT", "PASSWORD_TYPE_MD5", "PASSWORD_TYPE_SCRAM_SHA_256"};
 
 /* Represents password_check_hook parameters. */
 typedef struct PasswordCheckHookData

--- a/src/tleextension.c
+++ b/src/tleextension.c
@@ -139,10 +139,10 @@ typedef struct ExtensionVersionInfo
 } ExtensionVersionInfo;
 
 /* callback to cleanup on abort */
-bool		cb_registered = false;
+static bool cb_registered = false;
 
 /* global indicator we are manipulating pg_tle artifacts */
-bool		tleart = false;
+static bool tleart = false;
 #define SET_TLEART \
 	do { \
 		if (!cb_registered) \
@@ -158,7 +158,7 @@ bool		tleart = false;
 	} while (0)
 
 /* global indicator to use tle strings rather than files */
-bool		tleext = false;
+static bool tleext = false;
 #define SET_TLEEXT \
 	do { \
 		if (!cb_registered) \


### PR DESCRIPTION
  PG 18 introduced -Wmissing-variable-declarations to PostgreSQL's
  standard build flags (src/Makefile.global.in / CFLAGS_SL / bitcode
  CFLAGS), which clang now applies to extension builds too. The flag
  flags any file-scope, non-static variable definition that has no
  prior extern declaration in scope. pg_tle defines four such globals:

    * src/passcheck.c    : pass_types
    * src/tleextension.c : cb_registered, tleart, tleext

  All four are only used within the translation unit that defines
  them (grep confirms no other .c file references them and no header
  declares them extern), so they were always meant to be file-private.
  They were simply never marked 'static'.

Fix:
  Mark all four variables 'static'.

Hacked by Claude, tested by me.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
