### PR TITLE
Emit WARNING instead of NOTICE in extension scripts

### DIFF
--- a/pg_tle--1.0.0.sql
+++ b/pg_tle--1.0.0.sql
@@ -278,7 +278,7 @@ BEGIN
       SELECT FROM pg_catalog.pg_roles
       WHERE  rolname = 'pgtle_admin') THEN
 
-      RAISE NOTICE 'Role "pgtle_admin" already exists. Skipping.';
+      RAISE WARNING 'Role "pgtle_admin" already exists. Skipping.';
    ELSE
       CREATE ROLE pgtle_admin NOLOGIN;
    END IF;

--- a/pg_tle--1.0.4.sql
+++ b/pg_tle--1.0.4.sql
@@ -345,7 +345,7 @@ BEGIN
       SELECT FROM pg_catalog.pg_roles
       WHERE  rolname = 'pgtle_admin') THEN
 
-      RAISE NOTICE 'Role "pgtle_admin" already exists. Skipping.';
+      RAISE WARNING 'Role "pgtle_admin" already exists. Skipping.';
    ELSE
       CREATE ROLE pgtle_admin NOLOGIN;
    END IF;

--- a/pg_tle--1.1.1.sql
+++ b/pg_tle--1.1.1.sql
@@ -337,7 +337,7 @@ BEGIN
       SELECT FROM pg_catalog.pg_roles
       WHERE  rolname = 'pgtle_admin') THEN
 
-      RAISE NOTICE 'Role "pgtle_admin" already exists. Skipping.';
+      RAISE WARNING 'Role "pgtle_admin" already exists. Skipping.';
    ELSE
       CREATE ROLE pgtle_admin NOLOGIN;
    END IF;

--- a/pg_tle--1.3.4--1.4.0.sql
+++ b/pg_tle--1.3.4--1.4.0.sql
@@ -88,11 +88,11 @@ BEGIN
 
     IF feature = 'passcheck' THEN
         IF passcheck_enabled = 'off' THEN
-           RAISE NOTICE 'pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on';
+           RAISE WARNING 'pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on';
         ELSE
         -- passcheck_db_name is an optional param, we only emit a warning if it's non-empty and is not the current database
             IF passcheck_db != '' AND current_db != passcheck_db THEN
-                RAISE NOTICE '%', pg_catalog.FORMAT('pgtle.passcheck_db_name is currently %I. To trigger this passcheck function, register the function in that database.', passcheck_db)
+                RAISE WARNING '%', pg_catalog.FORMAT('pgtle.passcheck_db_name is currently %I. To trigger this passcheck function, register the function in that database.', passcheck_db)
                 USING HINT = pg_catalog.FORMAT('Alternatively, to use the current database for passcheck, set pgtle.passcheck_db_name = %I and reload the PostgreSQL configuration.', current_db);
             END IF;
         END IF;
@@ -100,10 +100,10 @@ BEGIN
 
     IF feature = 'clientauth' THEN
         IF clientauth_enabled = 'off' THEN
-            RAISE NOTICE 'pgtle.enable_clientauth is set to off. To enable clientauth, set pgtle.enable_clientauth = on';
+            RAISE WARNING 'pgtle.enable_clientauth is set to off. To enable clientauth, set pgtle.enable_clientauth = on';
         ELSE
             IF current_db != clientauth_db THEN
-                RAISE NOTICE '%', pg_catalog.FORMAT('pgtle.clientauth_db_name is currently %I. To trigger this clientauth function, register the function in that database.', clientauth_db)
+                RAISE WARNING '%', pg_catalog.FORMAT('pgtle.clientauth_db_name is currently %I. To trigger this clientauth function, register the function in that database.', clientauth_db)
                 USING HINT = pg_catalog.FORMAT('Alternatively, to use the current database for clientauth, set pgtle.clientauth_db_name = %I and reload the PostgreSQL configuration.', current_db);
             END IF;
         END IF;

--- a/test/expected/pg_tle_api.out
+++ b/test/expected/pg_tle_api.out
@@ -37,6 +37,7 @@ SELECT pg_reload_conf();
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 -- Do not expect an error
 ALTER ROLE testuser with password 'pass';
 ALTER SYSTEM SET pgtle.enable_password_check = 'require';
@@ -54,6 +55,7 @@ ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require but extension "pg_tle" is not installed
 -- Expect an error for require if no entries are present
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require, however no entries exist in "pgtle.feature_info" with the feature "passcheck"
 -- Test validuntil_null and validuntil_time
@@ -271,7 +273,7 @@ END;
 $$
 LANGUAGE PLPGSQL;
 SELECT pgtle.register_feature('pass.password_check_length_greater_than_8', 'passcheck');
-NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
  register_feature 
 ------------------
  
@@ -329,6 +331,7 @@ $_pgtle_$
 (1 row)
 
 CREATE EXTENSION test_unregister_feature;
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
 -- the feature should be in the table
 SELECT EXISTS(
   SELECT 1 FROM pgtle.feature_info
@@ -382,7 +385,7 @@ SELECT pg_reload_conf();
 
 \c -
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'passcheck');
-NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
  register_feature 
 ------------------
  
@@ -405,7 +408,7 @@ SELECT pg_reload_conf();
 
 \c -
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'passcheck');
-NOTICE:  pgtle.passcheck_db_name is currently test. To trigger this passcheck function, register the function in that database.
+WARNING:  pgtle.passcheck_db_name is currently test. To trigger this passcheck function, register the function in that database.
 HINT:  Alternatively, to use the current database for passcheck, set pgtle.passcheck_db_name = contrib_regression and reload the PostgreSQL configuration.
  register_feature 
 ------------------
@@ -428,7 +431,7 @@ SELECT pg_reload_conf();
 
 \c -
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'clientauth');
-NOTICE:  pgtle.enable_clientauth is set to off. To enable clientauth, set pgtle.enable_clientauth = on
+WARNING:  pgtle.enable_clientauth is set to off. To enable clientauth, set pgtle.enable_clientauth = on
  register_feature 
 ------------------
  
@@ -451,7 +454,7 @@ SELECT pg_reload_conf();
 
 \c -
 SELECT pgtle.register_feature('password_check_length_greater_than_8', 'clientauth');
-NOTICE:  pgtle.clientauth_db_name is currently postgres. To trigger this clientauth function, register the function in that database.
+WARNING:  pgtle.clientauth_db_name is currently postgres. To trigger this clientauth function, register the function in that database.
 HINT:  Alternatively, to use the current database for clientauth, set pgtle.clientauth_db_name = contrib_regression and reload the PostgreSQL configuration.
  register_feature 
 ------------------

--- a/test/expected/pg_tle_api_clusterwide.out
+++ b/test/expected/pg_tle_api_clusterwide.out
@@ -65,6 +65,7 @@ ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require but extension "pg_tle" is not installed in the passcheck database "contrib_regression"
 -- Expect an error for require if no entries are present
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 ALTER ROLE testuser with password 'pass';
 ERROR:  "pgtle.enable_password_check" feature is set to require, however no entries exist in "pgtle.feature_info" with the feature "passcheck" in the passcheck database "contrib_regression"
 -- Test validuntil_null and validuntil_time
@@ -276,7 +277,7 @@ END;
 $$
 LANGUAGE PLPGSQL;
 SELECT pgtle.register_feature('pass.password_check_length_greater_than_8', 'passcheck');
-NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
  register_feature 
 ------------------
  
@@ -334,6 +335,7 @@ $_pgtle_$
 (1 row)
 
 CREATE EXTENSION test_unregister_feature;
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
 -- the feature should be in the table
 SELECT EXISTS(
   SELECT 1 FROM pgtle.feature_info

--- a/test/expected/pg_tle_datatype.out
+++ b/test/expected/pg_tle_datatype.out
@@ -5,6 +5,7 @@
 */
 \pset pager off
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 -- create semi-privileged role to manipulate pg_tle artifacts
 CREATE ROLE dbadmin;
 GRANT pgtle_admin TO dbadmin;

--- a/test/expected/pg_tle_functions_acl.out
+++ b/test/expected/pg_tle_functions_acl.out
@@ -163,7 +163,7 @@ SELECT pgtle.install_extension_version_sql('', '', '');
 ERROR:  invalid extension name: ""
 DETAIL:  Extension names must not be empty.
 SELECT pgtle.register_feature('op(bytea)'::regprocedure, 'passcheck');
-NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
  register_feature 
 ------------------
  
@@ -171,7 +171,7 @@ NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgt
 
 SELECT pgtle.register_feature_if_not_exists('op(bytea)'::regprocedure,
     'passcheck');
-NOTICE:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
  register_feature_if_not_exists 
 --------------------------------
  f

--- a/test/expected/pg_tle_injection.out
+++ b/test/expected/pg_tle_injection.out
@@ -12,6 +12,7 @@ SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER;
 (1 row)
 
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 -- create an unprivileged role that is attempting to elevate privileges
 CREATE ROLE bad_actor NOSUPERUSER;
 -- this would be a trojan attack through the comment argument. this should fail.

--- a/test/expected/pg_tle_perms.out
+++ b/test/expected/pg_tle_perms.out
@@ -5,6 +5,7 @@
 */
 \pset pager off
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 -- create a role that initially does not have CREATE in this database
 CREATE ROLE tle_person;
 DO
@@ -159,6 +160,7 @@ GRANT pgtle_admin TO tle_person;
 -- become tle_person again. create the featureful extension.
 SET SESSION AUTHORIZATION tle_person;
 CREATE EXTENSION yes_features;
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
 -- insert directly into pgtle.feature_info
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'other_passcheck_hook', '');
 -- become the privileged user. revoke pgtle_admin from tle_person

--- a/test/expected/pg_tle_perms_1.out
+++ b/test/expected/pg_tle_perms_1.out
@@ -5,6 +5,7 @@
 */
 \pset pager off
 CREATE EXTENSION pg_tle;
+WARNING:  Role "pgtle_admin" already exists. Skipping.
 -- create a role that initially does not have CREATE in this database
 CREATE ROLE tle_person;
 DO
@@ -160,6 +161,7 @@ GRANT pgtle_admin TO tle_person;
 -- become tle_person again. create the featureful extension.
 SET SESSION AUTHORIZATION tle_person;
 CREATE EXTENSION yes_features;
+WARNING:  pgtle.enable_password_check is set to off. To enable passcheck, set pgtle.enable_password_check = on
 -- insert directly into pgtle.feature_info
 INSERT INTO pgtle.feature_info VALUES ('passcheck', 'public', 'other_passcheck_hook', '');
 -- become the privileged user. revoke pgtle_admin from tle_person


### PR DESCRIPTION



## Description of the change

### Bug
Seven `RAISE NOTICE` calls in the pg_tle install scripts never reach the client or the log. Operators get no guidance when they hit them.

### Root cause
Postgres's `execute_extension_script()` clamps `client_min_messages` and `log_min_messages` to at least `WARNING` for the duration of `CREATE/ALTER EXTENSION`. NOTICE-level messages raised from inside an extension script are dropped.

### Fix
Promote the seven NOTICE calls to WARNING so the guidance survives the clamp. Sites: the "role already exists" guard in `pg_tle--1.0.0.sql` / `1.0.4.sql` / `1.1.1.sql`, and four config-guidance messages inside `pgtle.register_feature` in `pg_tle--1.3.4--1.4.0.sql`.

## Branches
`aws/pg_tle:main` — `raise-warning-in-extension-scripts`, commit `c248746`.

## Testing
`make installcheck` on PostgreSQL 17.10, cold cluster: 10/10 regression + 107/107 TAP pass. Seven `.out` files updated to match the new severity label.


## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
